### PR TITLE
Modify a few scripts to work in Windows environment

### DIFF
--- a/scripts/run-development-dependencies.sh
+++ b/scripts/run-development-dependencies.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -ex
 
+# Disable path conversion when running Git Bash in Windows
+export MSYS_NO_PATHCONV=1
+
 HERE=$(dirname "$0")
 NETWORK=hint_nw
 DB=hint_db

--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.internal.os.OperatingSystem
+
 buildscript {
     ext.kotlin_version = '1.6.10'
 }
@@ -21,6 +23,9 @@ tasks.jacocoTestReport {
 group = 'org.imperial.mrc'
 sourceCompatibility = JavaVersion.VERSION_11
 def tomcatVersion = '9.0.65'
+
+// Determine npm command based on operating system. Windows needs 'npm.cmd'.
+def npmCommand = OperatingSystem.current().isWindows() ? 'npm.cmd' : 'npm'
 
 dependencies {
 
@@ -90,7 +95,7 @@ task compileFrontEnd() {
     }
     doLast {
         exec {
-            commandLine 'npm.cmd', "run", "build", "--prefix=$projectDir/static/"
+            commandLine npmCommand, "run", "build", "--prefix=$projectDir/static/"
         }
     }
 }
@@ -98,7 +103,7 @@ task compileFrontEnd() {
 task copyAssets() {
     doLast {
         exec {
-            commandLine 'npm.cmd', "run", "copy", "--prefix=$projectDir/static/"
+            commandLine npmCommand, "run", "copy", "--prefix=$projectDir/static/"
         }
     }
 }

--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -90,7 +90,7 @@ task compileFrontEnd() {
     }
     doLast {
         exec {
-            commandLine "npm", "run", "build", "--prefix=$projectDir/static/"
+            commandLine 'npm.cmd', "run", "build", "--prefix=$projectDir/static/"
         }
     }
 }
@@ -98,7 +98,7 @@ task compileFrontEnd() {
 task copyAssets() {
     doLast {
         exec {
-            commandLine "npm", "run", "copy", "--prefix=$projectDir/static/"
+            commandLine 'npm.cmd', "run", "copy", "--prefix=$projectDir/static/"
         }
     }
 }

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -7,7 +7,7 @@
     "sass": "gulp sass && gulp inject",
     "js": "webpack",
     "build": "rm -rf public && vue-cli-service build ./src/app/index.ts",
-    "serve": "rm -rf public && VUE_CLI_SERVICE_CONFIG_PATH=$PWD/vue.config.js vue-cli-service serve ./src/app/index.ts",
+    "serve": "rm -rf public && env VUE_CLI_SERVICE_CONFIG_PATH=$PWD/vue.config.js vue-cli-service serve ./src/app/index.ts",
     "copy": "cp -r ./templates/*.ftl ./public && cp -r ./assets/* ./public",
     "test": "vitest --run --coverage",
     "browser-test": "npx playwright test",


### PR DESCRIPTION
## Description

I made the following changes to get the client running locally in a Windows environment:

- Prevent automatic conversion of Unix paths to Windows paths (was causing Docker issues). Scripts work when run in Git Bash environment on Windows.
- Replace 'npm' with 'npm.cmd' in Gradle build config file to allow Windows to locate local npm installation.
- Add 'env' command in front of environment variable declaration for npm serve script in package.json.