### PR TITLE
[NM-43] Refactor current dataset select approach to make logic more reusable

### DIFF
--- a/src/app/static/src/app/apiService.ts
+++ b/src/app/static/src/app/apiService.ts
@@ -77,6 +77,11 @@ export class APIService<S extends string, E extends string> implements API<S, E>
         return this;
     };
 
+    withErrorCallback = (callback: (failure: Response) => void) => {
+        this._onError = callback;
+        return this;
+    };
+
     ignoreErrors = () => {
         this._ignoreErrors = true;
         return this;

--- a/src/app/static/src/app/components/adr/ADRIntegration.vue
+++ b/src/app/static/src/app/components/adr/ADRIntegration.vue
@@ -1,8 +1,8 @@
 <template>
-    <div v-if="loggedIn" class="mb-5">
+    <div v-if="!isGuest" class="mb-5">
         <adr-key v-if="!ssoLogin"></adr-key>
         <div v-if="ssoLogin || key">
-            <select-dataset></select-dataset>
+            <adr-dataset></adr-dataset>
             <div class="pt-3" id="adr-capacity" v-if="selectedDataset">
                 <span class="font-weight-bold align-self-stretch" v-translate="'adrAccessLevel'"></span>
                 <span v-tooltip="handleUploadPermission(hasUploadPermission, true)">
@@ -13,35 +13,29 @@
     </div>
 </template>
 <script lang="ts">
-    import {mapActionByName, mapStateProp, mapGetterByName} from "../../utils";
+    import {mapActionByName, mapStateProp} from "../../utils";
     import AdrKey from "./ADRKey.vue";
-    import SelectDataset from "./SelectDataset.vue";
-    import {ADRState} from "../../store/adr/adr";
+    import AdrDataset from "./ADRInputDataset.vue";
+    import {AdrDatasetType, ADRState} from "../../store/adr/adr";
     import i18next from "i18next";
     import {RootState} from "../../root";
     import {Language} from "../../store/translations/locales";
     import {BaselineState} from "../../store/baseline/baseline";
     import {Dataset} from "../../types";
     import {defineComponent} from "vue";
+    import {useADR} from "./useADR";
 
     const namespace = "adr";
 
     export default defineComponent({
         components: {
             "adr-key": AdrKey,
-            "select-dataset": SelectDataset
+            "adr-dataset": AdrDataset
+        },
+        setup() {
+            return useADR();
         },
         computed: {
-            isGuest: mapGetterByName(null, "isGuest"),
-            loggedIn(): boolean {
-                return !this.isGuest
-            },
-            ssoLogin: mapStateProp<ADRState, boolean>(namespace,
-                (state: ADRState) => state.ssoLogin),
-
-            key: mapStateProp<ADRState, string | null>(namespace,
-                (state: ADRState) => state.key),
-
             hasUploadPermission: mapStateProp<ADRState, boolean>(namespace,
                 (state: ADRState) => state.userCanUpload),
 
@@ -82,17 +76,9 @@
                 });
             }
         },
-        beforeMount() {
-            if (this.loggedIn) {
-
-                if (!this.ssoLogin) {
-                    this.fetchADRKey();
-                }
-            }
-        },
         watch: {
             key() {
-                this.getDatasets();
+                this.getDatasets(AdrDatasetType.Input);
             },
             selectedDataset() {
                 this.getUserCanUpload()
@@ -101,10 +87,6 @@
         mounted() {
             if(this.selectedDataset) {
                 this.getUserCanUpload();
-            }
-
-            if (this.loggedIn) {
-                this.ssoLoginMethod()
             }
         }
     })

--- a/src/app/static/src/app/components/adr/SelectDatasetModal.vue
+++ b/src/app/static/src/app/components/adr/SelectDatasetModal.vue
@@ -1,0 +1,130 @@
+<template>
+    <modal id="dataset" :open="open">
+        <h4 v-if="!loading" v-translate="'browseADR'"></h4>
+        <p v-if="loading" v-translate="'importingFiles'"></p>
+        <div v-if="!loading">
+            <label class="font-weight-bold" v-translate="'datasets'"></label>
+            <hint-tree-select id="datasetSelector"
+                              :multiple="false"
+                              :searchable="true"
+                              :options="datasetOptions"
+                              :placeholder="select"
+                              :disabled="fetchingDatasets"
+                              v-model="datasetId">
+                <template v-slot:option-label="{node}">
+                    <label v-html="node.raw.customLabel">
+                    </label>
+                </template>
+            </hint-tree-select>
+            <select-release :dataset-id="datasetId ? datasetId : null"
+                            :open="open"
+                            :dataset-type="datasetType"
+                            @selected-dataset-release="(newReleaseId) => datasetReleaseId = newReleaseId"
+                            @valid="(newValue) => valid = newValue">
+            </select-release>
+            <div :class="fetchingDatasets ? 'visible' : 'invisible'"
+                 style="margin-top: 15px"
+                 id="fetching-datasets">
+                <loading-spinner size="xs"></loading-spinner>
+                <span v-translate="'loadingDatasets'"></span>
+            </div>
+            <div v-if="fetchingError" id="fetch-error">
+                <div v-if="fetchingError.detail">{{fetchingError.detail}}</div>
+                <button @click="fetchDatasets"
+                        class="btn btn-red float-right"
+                        v-translate="'tryAgain'">
+                </button>
+            </div>
+        </div>
+        <div class="text-center" v-if="loading" id="loading-dataset">
+            <loading-spinner size="sm"></loading-spinner>
+        </div>
+        <template v-slot:footer v-if="!loading">
+            <button id="importBtn"
+                    type="button"
+                    :disabled="disableImport"
+                    class="btn btn-red"
+                    v-translate="'import'"
+                    @click="$emit('confirmImport', datasetId, datasetReleaseId)">
+            </button>
+            <button type="button"
+                    class="btn btn-white"
+                    v-translate="'cancel'"
+                    @click="$emit('closeModal')">
+            </button>
+        </template>
+    </modal>
+</template>
+
+<script setup lang="ts">
+import HintTreeSelect from "../HintTreeSelect.vue";
+import LoadingSpinner from "../LoadingSpinner.vue";
+import SelectRelease from "./SelectRelease.vue";
+import Modal from "../Modal.vue";
+import {useStore} from "vuex";
+import {RootState} from "../../root";
+import i18next from "i18next";
+import {computed, PropType, ref, watch, watchEffect} from "vue";
+import {AdrDatasetType} from "../../store/adr/adr";
+import {Release} from "../../types";
+
+// eslint-disable-next-line no-undef
+defineEmits<{
+    (e: "confirmImport", datasetId: string, release: Release): void
+    (e: "closeModal"): void
+}>();
+
+// eslint-disable-next-line no-undef
+const props = defineProps({
+    open: {
+        type: Boolean,
+        required: true
+    },
+    loading: {
+        type: Boolean,
+        required: true
+    },
+    datasetType: {
+        type: String as PropType<AdrDatasetType>,
+        required: true
+    },
+})
+
+const store = useStore<RootState>();
+
+const datasetId = ref<string | null>(null);
+const datasetReleaseId = ref<string | null>(null);
+const valid = ref<boolean>(true);
+
+const selectedDatasetId = computed(() => store.state.baseline.selectedDataset?.id);
+const select = computed(() => i18next.t("select", store.state.language));
+const fetchingDatasets = computed(() => store.state.adr.adrData[props.datasetType].fetchingDatasets);
+const fetchingError = computed(() => store.state.adr.adrData[props.datasetType].fetchingError);
+const datasets = computed(() => store.state.adr.adrData[props.datasetType].datasets);
+const disableImport = computed(() => !datasetId.value || !valid.value);
+
+const datasetOptions = computed(() => {
+    return datasets.value.map((d: any) => ({
+        id: d.id,
+        label: d.title,
+        customLabel: `${d.title}
+                            <div class="text-muted small" style="margin-top:-5px; line-height: 0.8rem">
+                                (${d.name})<br/>
+                                <span class="font-weight-bold">${d.organization.title}</span>
+                            </div>`,
+    }));
+});
+
+const fetchDatasets = () => store.dispatch("adr/getDatasets", props.datasetType);
+const preSelectDataset = () => {
+    if (selectedDatasetId.value && datasets.value.some((dataset: any) => dataset.id === selectedDatasetId.value)) {
+        datasetId.value = selectedDatasetId.value
+    }
+};
+watchEffect(() => {
+    if (props.open) {
+        preSelectDataset()
+    }
+});
+watch(datasets, preSelectDataset);
+</script>

--- a/src/app/static/src/app/components/adr/SelectDatasetModal.vue
+++ b/src/app/static/src/app/components/adr/SelectDatasetModal.vue
@@ -39,7 +39,7 @@
         <div class="text-center" v-if="loading" id="loading-dataset">
             <loading-spinner size="sm"></loading-spinner>
         </div>
-        <template v-slot:footer v-if="!loading">
+        <template v-slot:footer v-if="!loading && datasetId">
             <button id="importBtn"
                     type="button"
                     :disabled="disableImport"
@@ -66,11 +66,10 @@ import {RootState} from "../../root";
 import i18next from "i18next";
 import {computed, PropType, ref, watch, watchEffect} from "vue";
 import {AdrDatasetType} from "../../store/adr/adr";
-import {Release} from "../../types";
 
 // eslint-disable-next-line no-undef
 defineEmits<{
-    (e: "confirmImport", datasetId: string, release: Release): void
+    (e: "confirmImport", datasetId: string, release: string | null): void
     (e: "closeModal"): void
 }>();
 

--- a/src/app/static/src/app/components/adr/SelectRelease.vue
+++ b/src/app/static/src/app/components/adr/SelectRelease.vue
@@ -52,7 +52,7 @@
 <script lang="ts">
     import { mapActionByName, mapStateProp, mapMutationByName } from "../../utils";
     import HintTreeSelect from "../HintTreeSelect.vue";
-    import { ADRState } from "../../store/adr/adr";
+    import {AdrDatasetType, ADRState} from "../../store/adr/adr";
     import VueFeather from "vue-feather";
     import i18next from "i18next";
     import { Language } from "../../store/translations/locales";
@@ -82,7 +82,11 @@
             open: {
                 type: Boolean,
                 required: false
-            }
+            },
+            datasetType: {
+                type: String as PropType<AdrDatasetType>,
+                required: true
+            },
         },
         data(): Data {
             return {
@@ -91,10 +95,13 @@
             };
         },
         computed: {
-            releases: mapStateProp<ADRState, Release[]>(
+            adrData: mapStateProp<ADRState, ADRState["adrData"]>(
                 namespace,
-                (state: ADRState) => state.releases
+                (state: ADRState) => state.adrData
             ),
+            releases() {
+                return this.adrData[this.datasetType].releases
+            },
             initialRelease: mapStateProp<BaselineState, string | undefined>(
                 "baseline",
                 (state: BaselineState) => state.selectedDataset?.release
@@ -139,9 +146,9 @@
         watch: {
             datasetId(id) {
                 this.choiceADR = "useLatest";
-                this.clearReleases()
+                this.clearReleases({payload: {datasetType: this.datasetType}})
                 if (id) {
-                    this.getReleases(id);
+                    this.getReleases({id, datasetType: this.datasetType});
                 }
             },
             choiceADR(choice) {
@@ -150,7 +157,7 @@
                 }
             },
             releaseId() {
-                this.$emit("selected-dataset-release", this.releases.find((release: Release) => release.id === this.releaseId))
+                this.$emit("selected-dataset-release", this.releaseId)
             },
             valid() {
                 this.$emit("valid", this.valid);
@@ -160,7 +167,7 @@
             },
             open(){
                 if (this.open && this.datasetId){
-                    this.getReleases(this.datasetId);
+                    this.getReleases({id: this.datasetId, datasetType: this.datasetType});
                 }
             }
         },

--- a/src/app/static/src/app/components/adr/useADR.ts
+++ b/src/app/static/src/app/components/adr/useADR.ts
@@ -1,0 +1,34 @@
+import {useStore} from "vuex";
+import {computed, onBeforeMount, onMounted} from "vue";
+
+export const useADR = () => {
+    const store = useStore();
+
+    const isGuest = computed<boolean>(() => {
+        return store.getters["isGuest"]
+    });
+    const ssoLogin = computed<boolean>(() => {
+        return store.state.adr.ssoLogin
+    });
+    const key = computed<string | null>(() => {
+        return store.state.adr.key
+    });
+
+    onBeforeMount(() => {
+        if (!isGuest.value && !ssoLogin.value) {
+            store.dispatch("adr/fetchKey").then();
+        }
+    });
+
+    onMounted(() => {
+        if (!isGuest.value) {
+            store.dispatch("adr/ssoLoginMethod").then();
+        }
+    });
+
+    return {
+        isGuest,
+        ssoLogin,
+        key
+    }
+}

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.8.0";
+export const currentHintVersion = "3.8.1";

--- a/src/app/static/src/app/store/adr/adr.ts
+++ b/src/app/static/src/app/store/adr/adr.ts
@@ -5,13 +5,24 @@ import {actions} from "./actions";
 import {mutations} from "./mutations";
 import {RootState} from "../../root";
 
-export interface ADRState {
+export enum AdrDatasetType {
+    Input = "input",
+    Output = "output"
+}
+
+export interface ADRDatasetState {
     datasets: any[],
     releases: any[],
     fetchingDatasets: boolean,
+    fetchingError: Error | null,
+}
+
+export interface ADRState {
+    adrData: {
+        [key in AdrDatasetType]: ADRDatasetState
+    },
     key: string | null,
     keyError: Error | null,
-    adrError: Error | null,
     schemas: ADRSchemas | null,
     userCanUpload: boolean
     ssoLogin: boolean
@@ -19,13 +30,23 @@ export interface ADRState {
 
 export const initialADRState = (): ADRState => {
     return {
-        datasets: [],
-        releases: [],
+        adrData: {
+            input: {
+                datasets: [],
+                releases: [],
+                fetchingDatasets: false,
+                fetchingError: null
+            },
+            output: {
+                datasets: [],
+                releases: [],
+                fetchingDatasets: false,
+                fetchingError: null
+            }
+        },
         key: null,
         keyError: null,
-        adrError: null,
         schemas: null,
-        fetchingDatasets: false,
         userCanUpload: false,
         ssoLogin: false
     }

--- a/src/app/static/src/app/store/adr/mutations.ts
+++ b/src/app/static/src/app/store/adr/mutations.ts
@@ -1,5 +1,5 @@
-import {MutationTree} from "vuex";
-import {ADRState} from "./adr";
+import {MutationTree, Payload} from "vuex";
+import {AdrDatasetType, ADRState} from "./adr";
 import {ADRSchemas, PayloadWithType} from "../../types";
 import {Error} from "../../generated";
 
@@ -16,6 +16,13 @@ export enum ADRMutation {
     SetSSOLogin = "SetSSOLogin"
 }
 
+export interface DatasetTypePayload<T> extends Payload {
+    payload: {
+        datasetType: AdrDatasetType,
+        data: T
+    }
+}
+
 export const mutations: MutationTree<ADRState> = {
     [ADRMutation.UpdateKey](state: ADRState, action: PayloadWithType<string | null>) {
         state.key = action.payload;
@@ -29,24 +36,24 @@ export const mutations: MutationTree<ADRState> = {
         state.keyError = action.payload;
     },
 
-    [ADRMutation.SetADRError](state: ADRState, action: PayloadWithType<Error | null>) {
-        state.adrError = action.payload;
+    [ADRMutation.SetADRError](state: ADRState, action: DatasetTypePayload<Error | null>) {
+        state.adrData[action.payload.datasetType].fetchingError = action.payload.data;
     },
 
-    [ADRMutation.SetDatasets](state: ADRState, action: PayloadWithType<any[]>) {
-        state.datasets = action.payload;
+    [ADRMutation.SetDatasets](state: ADRState, action: DatasetTypePayload<any[]>) {
+        state.adrData[action.payload.datasetType].datasets = action.payload.data;
     },
 
-    [ADRMutation.SetReleases](state: ADRState, action: PayloadWithType<any[]>) {
-        state.releases = action.payload;
+    [ADRMutation.SetReleases](state: ADRState, action: DatasetTypePayload<any[]>) {
+        state.adrData[action.payload.datasetType].releases = action.payload.data;
     },
 
-    [ADRMutation.ClearReleases](state: ADRState) {
-        state.releases = [];
+    [ADRMutation.ClearReleases](state: ADRState, action: DatasetTypePayload<null>) {
+        state.adrData[action.payload.datasetType].releases = [];
     },
 
-    [ADRMutation.SetFetchingDatasets](state: ADRState, action: PayloadWithType<boolean>) {
-        state.fetchingDatasets = action.payload;
+    [ADRMutation.SetFetchingDatasets](state: ADRState, action: DatasetTypePayload<boolean>) {
+        state.adrData[action.payload.datasetType].fetchingDatasets = action.payload.data;
     },
 
     [ADRMutation.SetSchemas](state: ADRState, action: PayloadWithType<ADRSchemas>) {

--- a/src/app/static/src/app/store/baseline/baseline.ts
+++ b/src/app/static/src/app/store/baseline/baseline.ts
@@ -11,6 +11,7 @@ import {
 import { Dataset, Release, Dict, DatasetResourceSet, DatasetResource } from "../../types";
 import {ReadyState, RootState} from "../../root";
 import {resourceTypes} from "../../utils";
+import {AdrDatasetType} from "../adr/adr";
 
 export interface BaselineState extends ReadyState {
     selectedDataset: Dataset | null
@@ -69,7 +70,7 @@ export const baselineGetters = {
         const { selectedDataset } = state
 
         if (selectedDataset?.id && selectedDataset.resources) {
-            const selectedDatasetFromDatasets = rootState.adr.datasets
+            const selectedDatasetFromDatasets = rootState.adr.adrData[AdrDatasetType.Input].datasets
                 .find(dataset => dataset.id === selectedDataset.id) || null
 
             const checkResourceAvailable = (resourceType: string) => {

--- a/src/app/static/src/tests/adr/mutations.test.ts
+++ b/src/app/static/src/tests/adr/mutations.test.ts
@@ -1,5 +1,6 @@
-import {mockADRState, mockError} from "../mocks";
+import {mockADRDatasetState, mockADRDataState, mockADRState, mockError} from "../mocks";
 import {ADRMutation, mutations} from "../../app/store/adr/mutations";
+import {AdrDatasetType} from "../../app/store/adr/adr";
 
 describe("ADR mutations", () => {
     it("can update key", () => {
@@ -26,37 +27,45 @@ describe("ADR mutations", () => {
         expect(state.keyError).toBe(null);
     });
 
-    it("can set adr error", () => {
+    it.each(Object.values(AdrDatasetType))("can set adr error", (datasetType: AdrDatasetType) => {
         const state = mockADRState();
-        mutations[ADRMutation.SetADRError](state, {payload: mockError("whatevs")});
-        expect(state.adrError!!.detail).toBe("whatevs");
+        mutations[ADRMutation.SetADRError](state, {payload: {data: mockError("whatevs"), datasetType}});
+        expect(state.adrData[datasetType].fetchingError!!.detail).toBe("whatevs");
 
-        mutations[ADRMutation.SetADRError](state, {payload: null});
-        expect(state.adrError).toBe(null);
+        mutations[ADRMutation.SetADRError](state, {payload: {data: null, datasetType}});
+        expect(state.adrData[datasetType].fetchingError).toBe(null);
     });
 
-    it("can set datasets", () => {
+    it.each(Object.values(AdrDatasetType))("can set datasets", (datasetType: AdrDatasetType) => {
         const state = mockADRState();
-        mutations[ADRMutation.SetDatasets](state, {payload: [1, 2, 3]});
-        expect(state.datasets).toEqual([1, 2, 3]);
+        mutations[ADRMutation.SetDatasets](state, {payload: {data: [1, 2, 3], datasetType}});
+        expect(state.adrData[datasetType].datasets).toEqual([1, 2, 3]);
     });
 
-    it("can set fetching datasets", () => {
-        const state = mockADRState({fetchingDatasets: false});
-        mutations[ADRMutation.SetFetchingDatasets](state, {payload: true});
-        expect(state.fetchingDatasets).toBe(true);
+    it.each(Object.values(AdrDatasetType))("can set fetching datasets", (datasetType: AdrDatasetType) => {
+        const state = mockADRState({
+            adrData: mockADRDataState({
+                [datasetType]: mockADRDatasetState({fetchingDatasets: false})
+            })
+        });
+        mutations[ADRMutation.SetFetchingDatasets](state, {payload: {data: true, datasetType}});
+        expect(state.adrData[datasetType].fetchingDatasets).toBe(true);
     });
 
-    it("can set releases", () => {
+    it.each(Object.values(AdrDatasetType))("can set releases", (datasetType: AdrDatasetType) => {
         const state = mockADRState();
-        mutations[ADRMutation.SetReleases](state, {payload: [1, 2, 3]});
-        expect(state.releases).toEqual([1, 2, 3]);
+        mutations[ADRMutation.SetReleases](state, {payload: {data: [1, 2, 3], datasetType}});
+        expect(state.adrData[datasetType].releases).toEqual([1, 2, 3]);
     });
 
-    it("can clear releases", () => {
-        const state = mockADRState({releases: [1, 2, 3]});
-        mutations[ADRMutation.ClearReleases](state);
-        expect(state.releases).toEqual([]);
+    it.each(Object.values(AdrDatasetType))("can clear releases", (datasetType: AdrDatasetType) => {
+        const state = mockADRState({
+            adrData: mockADRDataState({
+                [datasetType]: mockADRDatasetState({releases: [1, 2, 3]})
+            })
+        });
+        mutations[ADRMutation.ClearReleases](state, {payload: {datasetType}});
+        expect(state.adrData[datasetType].releases).toEqual([]);
     });
 
     it("can set schemas", () => {

--- a/src/app/static/src/tests/adrUpload/actions.test.ts
+++ b/src/app/static/src/tests/adrUpload/actions.test.ts
@@ -1,4 +1,5 @@
 import {
+    mockADRDataState,
     mockADRState,
     mockADRUploadState,
     mockAxios,
@@ -232,7 +233,7 @@ describe("ADR upload actions", () => {
         const dispatch = vi.fn();
         const root = mockRootState({
             adr: mockADRState({
-                datasets: [],
+                adrData: mockADRDataState(),
                 schemas: {
                     baseUrl: "http://test",
                     outputZip: "inputs-unaids-naomi-output-zip",
@@ -328,7 +329,7 @@ describe("ADR upload actions", () => {
         const dispatch = vi.fn();
         const root = mockRootState({
             adr: mockADRState({
-                datasets: [],
+                adrData: mockADRDataState(),
                 schemas: {
                     baseUrl: "http://test",
                     outputZip: "inputs-unaids-naomi-output-zip",
@@ -398,7 +399,7 @@ describe("ADR upload actions", () => {
         const dispatch = vi.fn();
         const root = mockRootState({
             adr: mockADRState({
-                datasets: [],
+                adrData: mockADRDataState(),
                 schemas: {
                     baseUrl: "http://test",
                     outputZip: "inputs-unaids-naomi-output-zip",
@@ -456,7 +457,7 @@ describe("ADR upload actions", () => {
         const dispatch = vi.fn();
         const root = mockRootState({
             adr: mockADRState({
-                datasets: [],
+                adrData: mockADRDataState(),
                 schemas: {
                     baseUrl: "http://test",
                     outputZip: "inputs-unaids-naomi-output-zip",
@@ -533,7 +534,7 @@ describe("ADR upload actions", () => {
         const dispatch = vi.fn();
         const root = mockRootState({
             adr: mockADRState({
-                datasets: [],
+                adrData: mockADRDataState(),
                 schemas: {
                     baseUrl: "http://test",
                     outputZip: "inputs-unaids-naomi-output-zip",
@@ -657,7 +658,7 @@ describe("ADR upload actions", () => {
                 adr: {
                     namespaced: true,
                     state: mockADRState({
-                        datasets: [],
+                        adrData: mockADRDataState(),
                         schemas: {
                             baseUrl: "whatever",
                             outputZip: "inputs-unaids-naomi-output-zip",
@@ -690,7 +691,7 @@ describe("ADR upload actions", () => {
         const commit = vi.fn();
         const root = mockRootState({
             adr: mockADRState({
-                datasets: [],
+                adrData: mockADRDataState(),
                 schemas: {
                     baseUrl: "http://test"
                 } as any
@@ -732,7 +733,7 @@ describe("ADR upload actions", () => {
         const commit = vi.fn();
         const root = mockRootState({
             adr: mockADRState({
-                datasets: [],
+                adrData: mockADRDataState(),
                 schemas: {
                     baseUrl: "http://test"
                 } as any

--- a/src/app/static/src/tests/apiService.test.ts
+++ b/src/app/static/src/tests/apiService.test.ts
@@ -419,6 +419,25 @@ describe("ApiService", () => {
         })
     });
 
+    it("executes callback when using withErrorCallback", async () => {
+
+        mockAxios.onGet(`/baseline/`)
+            .reply(500, mockFailure("some error message"));
+
+        const errorCallback = vi.fn();
+
+        await api({rootState} as any)
+            .withErrorCallback(errorCallback)
+            .get("/baseline/");
+
+        expect(errorCallback.mock.calls).toHaveLength(1);
+        expect(errorCallback.mock.calls[0][0]).toStrictEqual({
+            data: {},
+            errors: [mockError("some error message")],
+            status: "failure",
+        });
+    });
+
     async function expectCouldNotParseAPIResponseError() {
         const commit = vi.fn();
         await api({commit, rootState} as any)

--- a/src/app/static/src/tests/baseline/getters.test.ts
+++ b/src/app/static/src/tests/baseline/getters.test.ts
@@ -1,5 +1,7 @@
 import {baselineGetters} from "../../app/store/baseline/baseline";
 import {
+    mockADRDatasetState,
+    mockADRDataState,
     mockADRState,
     mockBaselineState,
     mockDatasetResource,
@@ -9,6 +11,7 @@ import {
 } from "../mocks";
 import {ShapeResponse} from "../../app/generated";
 import {Dict} from "../../app/types";
+import {AdrDatasetType} from "../../app/store/adr/adr";
 
 it("is complete iff all files are present", () => {
     let state = mockBaselineState({
@@ -103,7 +106,11 @@ it("selectedDatasetAvailableResources only returns resources that the user has p
     });
     let rootState = mockRootState({
         adr: mockADRState({
-            datasets
+            adrData: mockADRDataState({
+                [AdrDatasetType.Input]: mockADRDatasetState({
+                    datasets
+                })
+            })
         })
     })
 
@@ -115,18 +122,22 @@ it("selectedDatasetAvailableResources only returns resources that the user has p
     });
     rootState = mockRootState({
         adr: mockADRState({
-            datasets: [
-                {
-                    id: "id1",
-                    title: "Some data",
-                    organization: {title: "org", id: "org-id"},
-                    name: "some-data",
-                    type: "naomi-data",
-                    resources: [
-                        {resource_type: "inputs-unaids-spectrum-file"}
+            adrData: mockADRDataState({
+                [AdrDatasetType.Input]: mockADRDatasetState({
+                    datasets: [
+                        {
+                            id: "id1",
+                            title: "Some data",
+                            organization: {title: "org", id: "org-id"},
+                            name: "some-data",
+                            type: "naomi-data",
+                            resources: [
+                                {resource_type: "inputs-unaids-spectrum-file"}
+                            ]
+                        }
                     ]
-                }
-            ]
+                })
+            })
         })
     })
     expect(baselineGetters.selectedDatasetAvailableResources(state, getters, rootState)).toStrictEqual({

--- a/src/app/static/src/tests/components/adr/ADRIntegration.test.ts
+++ b/src/app/static/src/tests/components/adr/ADRIntegration.test.ts
@@ -7,7 +7,7 @@ import registerTranslations from "../../../app/store/translations/registerTransl
 import {shallowMount} from "@vue/test-utils";
 import ADRKey from "../../../app/components/adr/ADRKey.vue";
 import ADRIntegration from "../../../app/components/adr/ADRIntegration.vue";
-import SelectDataset from "../../../app/components/adr/SelectDataset.vue";
+import SelectDataset from "../../../app/components/adr/ADRInputDataset.vue";
 import {ADRMutation, mutations} from "../../../app/store/adr/mutations";
 import {getters} from "../../../app/store/root/getters";
 import {ADRState} from "../../../app/store/adr/adr";

--- a/src/app/static/src/tests/components/adr/selectDatasetModal.test.ts
+++ b/src/app/static/src/tests/components/adr/selectDatasetModal.test.ts
@@ -1,0 +1,319 @@
+import SelectRelease from "../../../app/components/adr/SelectRelease.vue";
+import {expectTranslatedWithStoreType, mountWithTranslate} from "../../testHelpers";
+import SelectDatasetModal from "../../../app/components/adr/SelectDatasetModal.vue";
+import {AdrDatasetType, ADRState} from "../../../app/store/adr/adr";
+import {nextTick} from "vue";
+import TreeSelect from "@reside-ic/vue3-treeselect";
+import {
+    mockADRDatasetState,
+    mockADRDataState,
+    mockADRState,
+    mockBaselineState,
+    mockDatasetResource,
+    mockError,
+    mockRootState
+} from "../../mocks";
+import HintTreeSelect from "../../../app/components/HintTreeSelect.vue";
+import LoadingSpinner from "../../../app/components/LoadingSpinner.vue";
+import {BaselineState} from "../../../app/store/baseline/baseline";
+import Vuex, {Store} from "vuex";
+import registerTranslations from "../../../app/store/translations/registerTranslations";
+import {RootState} from "../../../app/root";
+import Modal from "../../../app/components/Modal.vue";
+import {ADRMutation} from "../../../app/store/adr/mutations";
+
+describe("select dataset modal", () => {
+
+    const fakeDataset = {
+        id: "id1",
+        title: "Some data",
+        url: "www.adr.com/naomi-data/some-data",
+        organization: {title: "org", id: "org-id"},
+        name: "some-data",
+        type: "naomi-data",
+        resources: {
+            pjnz: null,
+            program: null,
+            pop: null,
+            survey: null,
+            shape: mockDatasetResource({
+                url: "shape.geojson",
+                lastModified: "2020-11-03",
+                metadataModified: "2020-11-04",
+                name: "Shape Resource"
+            }),
+            anc: null,
+            vmmc: null
+        }
+    };
+
+    const fakeDataset2 = {
+        id: "id2",
+        title: "Some data 2",
+        url: "www.adr.com/naomi-data/some-data",
+        organization: {title: "org", id: "org-id"},
+        name: "some-data",
+        type: "naomi-data",
+        resources: {
+            pjnz: null,
+            program: null,
+            pop: null,
+            survey: null,
+            shape: mockDatasetResource({
+                id: "2",
+                url: "shape.geojson",
+                lastModified: "2020-11-03",
+                metadataModified: "2020-11-04",
+                name: "Shape Resource"
+            }),
+            anc: null,
+            vmmc: null
+        }
+    };
+
+    const fakeDatasets = [fakeDataset, fakeDataset2]
+
+    const fakeRelease = {
+        id: "1.0",
+        name: "release1",
+        notes: "some notes",
+        activity_id: "activityId",
+    };
+
+    const mockDispatch = vi.fn();
+
+    const getStore = (baselineState: Partial<BaselineState> = {}, adrData: Partial<ADRState["adrData"]> = {}) => {
+        const allAdrData = mockADRDataState({
+            [AdrDatasetType.Input]: mockADRDatasetState({
+                datasets: fakeDatasets,
+                releases: [],
+            }),
+            ...adrData
+        })
+        const store = new Vuex.Store({
+            state: mockRootState({
+                baseline: mockBaselineState(baselineState),
+                adr: mockADRState({
+                    adrData: allAdrData
+                })
+            }),
+            modules: {
+                baseline: {
+                    namespaced: true,
+                    state: mockBaselineState(baselineState)
+                },
+                adr: {
+                    namespaced: true,
+                    state: mockADRState({
+                        adrData: allAdrData
+                    }),
+                    actions: {
+                        getReleases: vi.fn()
+                    },
+                    mutations: {
+                        [ADRMutation.ClearReleases]: vi.fn(),
+                        [ADRMutation.SetReleases]: vi.fn()
+                    }
+                }
+            },
+        });
+        store.dispatch = mockDispatch;
+        registerTranslations(store);
+        return store;
+    }
+
+    const mountSelectDataset = (store: Store<RootState>) => {
+        return mountWithTranslate(SelectDatasetModal, store, {
+            global: {
+                plugins: [store]
+            },
+            propsData: {
+                datasetType: AdrDatasetType.Input,
+                open: true
+            },
+        });
+    };
+
+    afterEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it("passes open prop to modal", async () => {
+        const store = getStore();
+        const wrapper = mountSelectDataset(store);
+        expect((wrapper.findComponent(Modal).props() as any).open).toBeTruthy();
+
+        await wrapper.setProps({open: false} as any);
+        expect((wrapper.findComponent(Modal).props() as any).open).toBeFalsy();
+    });
+
+    it("renders select dataset dropdown", async () => {
+        const store = getStore();
+        const wrapper = mountSelectDataset(store);
+        const select = wrapper.findComponent(HintTreeSelect);
+        expect((select.props() as any).multiple).toBe(false);
+
+        const expectedOptions = [
+            {
+                id: "id1",
+                label: "Some data",
+                customLabel: `Some data
+                            <div class="text-muted small" style="margin-top:-5px; line-height: 0.8rem">
+                                (some-data)<br/>
+                                <span class="font-weight-bold">org</span>
+                            </div>`
+            },
+            {
+                id: "id2",
+                label: "Some data 2",
+                customLabel: `Some data 2
+                            <div class="text-muted small" style="margin-top:-5px; line-height: 0.8rem">
+                                (some-data)<br/>
+                                <span class="font-weight-bold">org</span>
+                            </div>`
+            }
+        ]
+
+        expect((select.props() as any).options).toStrictEqual(expectedOptions);
+    });
+
+    it("shows current dataset in dropdown if in known datasets", async () => {
+        const store = getStore({selectedDataset: fakeDataset}, {
+            [AdrDatasetType.Input]: mockADRDatasetState({
+                datasets: [fakeDataset, fakeDataset2],
+            })
+        });
+        const wrapper = mountSelectDataset(store);
+
+        expect((wrapper.findComponent(HintTreeSelect).props() as any)["modelValue"]).toBe(fakeDataset.id);
+    });
+
+    it("current dataset is not preselected if there is no selectedDataset", async () => {
+        const store = getStore();
+        const wrapper = mountSelectDataset(store);
+
+        expect((wrapper.findComponent(HintTreeSelect).props() as any)["modelValue"]).toBe(null);
+    });
+
+    it("current dataset is preselected if datasets change", async () => {
+        const store = getStore({selectedDataset: fakeDataset2}, {
+            [AdrDatasetType.Input]: mockADRDatasetState({
+                datasets: [fakeDataset],
+                fetchingError: mockError("error text")
+            })
+        });
+        const wrapper = mountSelectDataset(store);
+
+        expect((wrapper.findComponent(HintTreeSelect).props() as any)["modelValue"]).toBe(null);
+        store.state.adr.adrData[AdrDatasetType.Input].datasets = fakeDatasets
+        await nextTick();
+        expect((wrapper.findComponent(HintTreeSelect).props() as any)["modelValue"]).toBe("id2");
+
+        // Release were fetched
+        expect(mockDispatch.mock.calls).toHaveLength(1);
+        expect(mockDispatch.mock.calls[0][0]).toBe("adr/getReleases")
+        expect(mockDispatch.mock.calls[0][1]).toStrictEqual({id: "id2", datasetType: AdrDatasetType.Input})
+    });
+
+    it("renders select release", async () => {
+        const store = getStore({selectedDataset: fakeDataset2});
+        const wrapper = mountSelectDataset(store);
+
+        const selectRelease = wrapper.findComponent(SelectRelease)
+        expect((selectRelease.props() as any).datasetId).toBe("id2");
+        expect((selectRelease.props() as any).open).toBe(true);
+    });
+
+    it("renders message and button on error fetching datasets", async () => {
+        const store = getStore({}, {
+            [AdrDatasetType.Input]: mockADRDatasetState({
+                datasets: [],
+                fetchingError: mockError("error text")
+            })
+        });
+        const wrapper = mountSelectDataset(store);
+
+        expect(wrapper.vm.open).toBe(true);
+        expect(wrapper.find("#fetch-error div").text()).toBe("error text");
+        await expectTranslatedWithStoreType(wrapper.find("#fetch-error button"), "Try again", "Réessayer",
+            "Tente novamente", store);
+
+        // Trying again disaptches action
+        await wrapper.find("#fetch-error button").trigger("click");
+        expect(mockDispatch.mock.calls).toHaveLength(1);
+        expect(mockDispatch.mock.calls[0][0]).toBe("adr/getDatasets")
+        expect(mockDispatch.mock.calls[0][1]).toBe(AdrDatasetType.Input)
+    });
+
+    it("hides fetching dataset controls, and enables TreeSelect, when not fetching", () => {
+        const store = getStore();
+        const wrapper = mountSelectDataset(store);
+        expect(wrapper.find("#fetching-datasets").classes()).toStrictEqual(["invisible"]);
+        expect((wrapper.findComponent(TreeSelect).attributes("disabled"))).toBeUndefined();
+    });
+
+    it("shows fetching dataset controls, and disables TreeSelect, when fetching", async () => {
+        const store = getStore({}, {
+            [AdrDatasetType.Input]: mockADRDatasetState({
+                datasets: [],
+                fetchingDatasets: true
+            })
+        });
+        const wrapper = mountSelectDataset(store);
+        expect(wrapper.find("#fetching-datasets").classes()).toStrictEqual(["visible"]);
+        expect((wrapper.findComponent(TreeSelect).attributes("disabled"))).toBeUndefined();
+
+        expect((wrapper.find("#fetching-datasets").findComponent(LoadingSpinner).props() as any).size).toBe("xs");
+        await expectTranslatedWithStoreType(wrapper.find("#fetching-datasets span"),
+            "Loading datasets", "Chargement de vos ensembles de données", "A carregar conjuntos de dados", store);
+    });
+
+    it("disables import button if no dataset selected", async () => {
+        const store = getStore({selectedDataset: null});
+        const wrapper = mountSelectDataset(store);
+
+        expect((wrapper.find("button").element as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it("disables import button if release not valid", async () => {
+        const store = getStore({selectedDataset: fakeDataset2});
+        const wrapper = mountSelectDataset(store);
+
+        const importButton = wrapper.find("button").element as HTMLButtonElement
+        expect(importButton.disabled).toBeFalsy();
+
+        const selectRelease = wrapper.findComponent(SelectRelease);
+        await selectRelease.vm.$emit("valid", false);
+        expect(importButton.disabled).toBeTruthy();
+
+        await selectRelease.vm.$emit("valid", true);
+        expect(importButton.disabled).toBeFalsy();
+    });
+
+    it("emits confirmImport event when the import button is clicked without release", async () => {
+        const store = getStore({selectedDataset: fakeDataset2});
+        const wrapper = mountSelectDataset(store);
+
+        const button = wrapper.find("#importBtn");
+        await button.trigger("click");
+
+        expect(wrapper.emitted()).toHaveProperty("confirmImport");
+        expect(wrapper.emitted().confirmImport).toHaveLength(1);
+        expect(wrapper.emitted().confirmImport[0]).toStrictEqual([fakeDataset2.id, undefined]);
+    });
+
+    it("emits confirmImport event with a release if selected", async () => {
+        const store = getStore({selectedDataset: fakeDataset2});
+        const wrapper = mountSelectDataset(store);
+
+        const selectRelease = wrapper.findComponent(SelectRelease)
+        await selectRelease.vm.$emit("selected-dataset-release", fakeRelease);
+
+        const button = wrapper.find("#importBtn");
+        await button.trigger("click");
+
+        expect(wrapper.emitted()).toHaveProperty("confirmImport");
+        expect(wrapper.emitted().confirmImport).toHaveLength(1);
+        expect(wrapper.emitted().confirmImport[0]).toStrictEqual([fakeDataset2.id, fakeRelease]);
+    });
+})

--- a/src/app/static/src/tests/components/adr/selectRelease.test.ts
+++ b/src/app/static/src/tests/components/adr/selectRelease.test.ts
@@ -2,13 +2,14 @@ import SelectRelease from "../../../app/components/adr/SelectRelease.vue";
 import Vuex from "vuex";
 import {ADRMutation} from "../../../app/store/adr/mutations";
 import registerTranslations from "../../../app/store/translations/registerTranslations";
-import {mockRootState} from "../../mocks";
+import {mockADRDatasetState, mockADRDataState, mockRootState} from "../../mocks";
 import {expectTranslated, mountWithTranslate, shallowMountWithTranslate} from "../../testHelpers";
 import {Language} from "../../../app/store/translations/locales";
 import {Dataset} from "../../../app/types";
 import VueFeather from "vue-feather";
 import {nextTick} from "vue";
 import HintTreeSelect from "../../../app/components/HintTreeSelect.vue";
+import {AdrDatasetType} from "../../../app/store/adr/adr";
 
 describe("select release", () => {
 
@@ -49,7 +50,11 @@ describe("select release", () => {
                 adr: {
                     namespaced: true,
                     state: {
-                        releases
+                        adrData: mockADRDataState({
+                            [AdrDatasetType.Input]: mockADRDatasetState({
+                                releases
+                            })
+                        })
                     },
                     actions: {
                         getDatasets: vi.fn(),
@@ -81,7 +86,10 @@ describe("select release", () => {
         const rendered = mountWithTranslate(SelectRelease, store, {
             global: {
                 plugins: [store]
-            }
+            },
+            propsData: {
+                datasetType: AdrDatasetType.Input
+            },
         });
         await rendered.setProps({datasetId: "datasetId"})
         expect(getReleasesMock.mock.calls.length).toBe(1);
@@ -127,7 +135,10 @@ describe("select release", () => {
         const rendered = shallowMountWithTranslate(SelectRelease, store, {
             global: {
                 plugins: [store]
-            }, 
+            },
+            propsData: {
+                datasetType: AdrDatasetType.Input
+            },
         });
         await rendered.setProps({datasetId: "datasetId"})
         expect(rendered.find("#selectRelease").exists()).toBe(false);
@@ -138,7 +149,10 @@ describe("select release", () => {
         const rendered = shallowMountWithTranslate(SelectRelease, store, {
             global: {
                 plugins: [store]
-            }, 
+            },
+            propsData: {
+                datasetType: AdrDatasetType.Input
+            },
         });
         expect(rendered.find("#selectRelease").exists()).toBe(false);
     });
@@ -148,7 +162,10 @@ describe("select release", () => {
         const rendered = shallowMountWithTranslate(SelectRelease, store, {
             global: {
                 plugins: [store]
-            }, 
+            },
+            propsData: {
+                datasetType: AdrDatasetType.Input
+            },
         });
         await rendered.setProps({datasetId: "datasetId"})
         expect(getReleasesMock.mock.calls.length).toBe(1);
@@ -165,7 +182,10 @@ describe("select release", () => {
                 global: {
                     plugins: [store],
                     directives: {"tooltip": mockTooltip}
-                }
+                },
+                propsData: {
+                    datasetType: AdrDatasetType.Input
+                },
             });
         await rendered.setProps({datasetId: "datasetId"})
 
@@ -184,7 +204,10 @@ describe("select release", () => {
                 global: {
                     plugins: [store],
                     directives: {"tooltip": mockTooltip}
-                }
+                },
+                propsData: {
+                    datasetType: AdrDatasetType.Input
+                },
             });
         await rendered.setProps({datasetId: "datasetId"})
 
@@ -203,7 +226,10 @@ describe("select release", () => {
                 global: {
                     plugins: [store],
                     directives: {"tooltip": mockTooltip}
-                }
+                },
+                propsData: {
+                    datasetType: AdrDatasetType.Input
+                },
             });
         await rendered.setProps({datasetId: "datasetId"})
 
@@ -216,7 +242,10 @@ describe("select release", () => {
         const rendered = mountWithTranslate(SelectRelease, store, {
             global: {
                 plugins: [store]
-            }, 
+            },
+            propsData: {
+                datasetType: AdrDatasetType.Input
+            },
         });
         await rendered.setProps({datasetId: "datasetId"})
         const select = rendered.findComponent(HintTreeSelect);
@@ -231,7 +260,11 @@ describe("select release", () => {
         const rendered = mountWithTranslate(SelectRelease, store, {
             global: {
                 plugins: [store]
-            }, props: {datasetId: "datasetId"}
+            },
+            props: {
+                datasetId: "datasetId",
+                datasetType: AdrDatasetType.Input
+            }
         });
         const select = rendered.findComponent(HintTreeSelect);
         expect(select.props("disabled")).toBe(true);
@@ -243,12 +276,16 @@ describe("select release", () => {
         const rendered = mountWithTranslate(SelectRelease, store, {
             global: {
                 plugins: [store]
-            }, props: {datasetId: "datasetId"}
+            },
+            props: {
+                datasetId: "datasetId",
+                datasetType: AdrDatasetType.Input
+            }
         });
         const selectWrapper = rendered.findComponent(HintTreeSelect);
         expect(!rendered.vm.useRelease).toBe(true);
         expect((rendered.vm.$data as any).releaseId).toBeUndefined();
-        store.state.adr.releases = releasesArray;
+        store.state.adr.adrData[AdrDatasetType.Input].releases = releasesArray;
         (rendered.vm as any).$options.watch.releases.call(rendered.vm);
         await nextTick();
         // need to manually trigger watcher to cause treeselect re-render
@@ -263,7 +300,12 @@ describe("select release", () => {
         const rendered = mountWithTranslate(SelectRelease, store, {
             global: {
                 plugins: [store]
-            }, props: {datasetId: "datasetId", choiceADR: "useRelease"}
+            },
+            props: {
+                datasetId: "datasetId",
+                choiceADR: "useRelease",
+                datasetType: AdrDatasetType.Input
+            }
         });
         const select = rendered.findComponent(HintTreeSelect);
         expect(select.props("disabled")).toBe(true);
@@ -276,14 +318,21 @@ describe("select release", () => {
         const rendered = shallowMountWithTranslate(SelectRelease, store, {
             global: {
                 plugins: [store]
-            }, 
+            },
+            propsData: {
+                datasetType: AdrDatasetType.Input
+            },
         });
         await rendered.setProps({datasetId: "datasetId"})
         expect(spy).toHaveBeenCalledTimes(1)
-        expect(spy.mock.calls[0][spy.mock.calls[0].length - 1]).toBe("datasetId")
+        const expectedPayload = {
+            id: "datasetId",
+            datasetType: AdrDatasetType.Input
+        }
+        expect(spy.mock.calls[0][spy.mock.calls[0].length - 1]).toStrictEqual(expectedPayload)
         await rendered.setProps({open: true})
         expect(spy).toHaveBeenCalledTimes(2)
-        expect(spy.mock.calls[1][spy.mock.calls[1].length - 1]).toBe("datasetId")
+        expect(spy.mock.calls[1][spy.mock.calls[1].length - 1]).toStrictEqual(expectedPayload)
     });
     
 
@@ -292,13 +341,16 @@ describe("select release", () => {
         const rendered = shallowMountWithTranslate(SelectRelease, store, {
             global: {
                 plugins: [store]
-            }, 
+            },
+            propsData: {
+                datasetType: AdrDatasetType.Input
+            },
         });
         await rendered.setProps({datasetId: "datasetId"})
         const selectRelease = rendered.findAll("input")[1]
         await selectRelease.trigger("click")
         await rendered.setData({releaseId: "releaseId"})
-        expect(rendered.emitted("selected-dataset-release")).toStrictEqual([[undefined], [releasesArray[0]]])
+        expect(rendered.emitted("selected-dataset-release")).toStrictEqual([[undefined], [releasesArray[0].id]])
     });
 
     it("selecting a release emits true valid", async () => {
@@ -306,7 +358,10 @@ describe("select release", () => {
         const rendered = shallowMountWithTranslate(SelectRelease, store, {
             global: {
                 plugins: [store]
-            }, 
+            },
+            propsData: {
+                datasetType: AdrDatasetType.Input
+            },
         });
         await rendered.setProps({datasetId: "datasetId"})
         const selectRelease = rendered.findAll("input")[1]
@@ -321,7 +376,10 @@ describe("select release", () => {
         const rendered = mountWithTranslate(SelectRelease, store, {
             global: {
                 plugins: [store]
-            }
+            },
+            propsData: {
+                datasetType: AdrDatasetType.Input
+            },
         });
         await rendered.setProps({datasetId: "datasetId"})
         const selectRelease = rendered.findAll("input")[1];

--- a/src/app/static/src/tests/integration/adr-dataset.itest.ts
+++ b/src/app/static/src/tests/integration/adr-dataset.itest.ts
@@ -8,6 +8,7 @@ import {SurveyAndProgramMutation} from "../../app/store/surveyAndProgram/mutatio
 import {getFormData} from "./helpers";
 import {ADRMutation} from "../../app/store/adr/mutations";
 import {UploadFile} from "../../app/types";
+import {AdrDatasetType} from "../../app/store/adr/adr";
 
 // this suite tests all endpoints that talk to the ADR
 // we put them in a suite of their own so that we can run
@@ -41,7 +42,7 @@ describe("ADR dataset-related actions", () => {
 
     it("can fetch ADR datasets", async () => {
         const commit = vi.fn();
-        await adrActions.getDatasets({commit, rootState} as any);
+        await adrActions.getDatasets({commit, rootState} as any, AdrDatasetType.Input);
 
         expect(commit.mock.calls[0][0]["type"]).toBe(ADRMutation.SetFetchingDatasets);
         expect(commit.mock.calls[0][0]["payload"]).toBe(true);
@@ -64,7 +65,7 @@ describe("ADR dataset-related actions", () => {
             adr: { schemas }
         };
 
-        await adrActions.getDatasets({commit, rootState} as any);
+        await adrActions.getDatasets({commit, rootState} as any, AdrDatasetType.Input);
         expect(commit.mock.calls[0][0]).toStrictEqual({type: ADRMutation.SetFetchingDatasets, payload: true});
 
         expect(commit.mock.calls[1][0]["type"]).toBe(ADRMutation.SetADRError);
@@ -82,11 +83,11 @@ describe("ADR dataset-related actions", () => {
     it("can get releases", async () => {
         const commit = vi.fn();
 
-        await adrActions.getDatasets({commit, rootState} as any);
+        await adrActions.getDatasets({commit, rootState} as any, AdrDatasetType.Input);
 
         vi.resetAllMocks();
 
-        await adrActions.getReleases({commit, rootState} as any, "antarctica-country-estimates-2022-1");
+        await adrActions.getReleases({commit, rootState} as any, {id: "antarctica-country-estimates-2022-1", datasetType: AdrDatasetType.Input});
         expect(commit.mock.calls[0][0].type).toBe(ADRMutation.SetReleases)
         expect(commit.mock.calls[0][0].payload.length).toBeGreaterThan(0);
         expect(commit.mock.calls[0][0].payload[0].name).toBeTruthy();
@@ -97,7 +98,7 @@ describe("ADR dataset-related actions", () => {
         const commit = vi.fn();
 
         // 1. get datasets
-        await adrActions.getDatasets({commit, rootState} as any);
+        await adrActions.getDatasets({commit, rootState} as any, AdrDatasetType.Input);
 
         // 2. select a naomi dev dataset
         expect(commit.mock.calls[2][0].type).toStrictEqual(ADRMutation.SetDatasets);
@@ -130,7 +131,7 @@ describe("ADR dataset-related actions", () => {
         });
 
         // 1. get datasets
-        await adrActions.getDatasets({commit, rootState} as any);
+        await adrActions.getDatasets({commit, rootState} as any, AdrDatasetType.Input);
 
         // 2. select a naomi dev dataset
         expect(commit.mock.calls[2][0].type).toStrictEqual(ADRMutation.SetDatasets);
@@ -343,7 +344,7 @@ describe("ADR dataset-related actions", () => {
 
 const getSelectedDatasetState = async () => {
     const commitDataset = vi.fn();
-    await adrActions.getDatasets({commit: commitDataset, rootState} as any);
+    await adrActions.getDatasets({commit: commitDataset, rootState} as any, AdrDatasetType.Input);
     const datasets = commitDataset.mock.calls[2][0]["payload"];
     return {
         selectedDataset:

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -45,7 +45,7 @@ import {
 import {initialProjectsState, ProjectsState} from "../app/store/projects/projects";
 import {initialModelCalibrateState, ModelCalibrateState} from "../app/store/modelCalibrate/modelCalibrate";
 import { HintrVersionState, initialHintrVersionState } from "../app/store/hintrVersion/hintrVersion";
-import {ADRState, initialADRState} from "../app/store/adr/adr";
+import {ADRDatasetState, ADRState, initialADRState} from "../app/store/adr/adr";
 import {ADRUploadState, initialADRUploadState} from "../app/store/adrUpload/adrUpload";
 import {DownloadResultsState, initialDownloadResultsState} from "../app/store/downloadResults/downloadResults";
 import {ReviewInputState, initialReviewInputState} from "../app/store/reviewInput/reviewInput";
@@ -68,9 +68,27 @@ export const mockPasswordState = (props?: Partial<PasswordState>): PasswordState
     }
 };
 
-export const mockADRState =  (props?: Partial<ADRState>): ADRState => {
+export const mockADRState = (props?: Partial<ADRState>): ADRState => {
     return {
         ...initialADRState(),
+        ...props
+    }
+};
+
+export const mockADRDatasetState = (props?: Partial<ADRDatasetState>): ADRDatasetState => {
+    return {
+        datasets: ["TEST DATASETS"],
+        releases: ["TEST RELEASES"],
+        fetchingDatasets: false,
+        fetchingError: null,
+        ...props
+    }
+};
+
+export const mockADRDataState = (props?: Partial<ADRState["adrData"]>): ADRState["adrData"] => {
+    return {
+        input: mockADRDatasetState(),
+        output: mockADRDatasetState(),
         ...props
     }
 };

--- a/src/app/static/src/tests/root/getters.test.ts
+++ b/src/app/static/src/tests/root/getters.test.ts
@@ -16,7 +16,9 @@ import {
     mockProjectOutputState,
     mockProjectsState,
     mockRootState,
-    mockSurveyAndProgramState
+    mockSurveyAndProgramState,
+    mockADRDataState,
+    mockADRDatasetState
 } from "../mocks";
 import {RootState} from "../../app/root";
 import {initialDownloadResults} from "../../app/store/downloadResults/downloadResults";
@@ -65,16 +67,25 @@ describe("root getters", () => {
 
     it("gets adr errors", async () => {
 
-        const adrError = mockError("something went wrong");
-        const keyError = mockError("something else went wrong");
+        const keyError = mockError("key something else went wrong");
+        const inputFetchError = mockError("input something went wrong");
+        const outputFetchError = mockError("output something went wrong");
+        const adrData = mockADRDataState({
+            input: mockADRDatasetState({
+                fetchingError: inputFetchError
+            }),
+            output: mockADRDatasetState({
+                fetchingError: outputFetchError
+            })
+        });
 
         const stateWithErrors = mockADRState({
-            adrError: adrError,
+            adrData: adrData,
             keyError: keyError
         });
 
         const result = getResult({adr: stateWithErrors});
-        expectArraysEqual(result, [adrError, keyError]);
+        expectArraysEqual(result, [inputFetchError, outputFetchError, keyError]);
     });
 
     it("gets adr upload errors", async () => {

--- a/src/app/static/src/tests/root/mutations.test.ts
+++ b/src/app/static/src/tests/root/mutations.test.ts
@@ -3,22 +3,22 @@ import {initialModelRunState} from "../../app/store/modelRun/modelRun";
 import {initialModelOptionsState} from "../../app/store/modelOptions/modelOptions";
 
 import {
+    mockADRDataState,
     mockADRState,
-    mockAncResponse,
     mockBaselineState,
     mockDownloadResultsState,
     mockError,
     mockErrorsState,
-    mockReviewInputState,
     mockLoadState,
     mockMetadataState,
     mockModelCalibrateState,
     mockModelOptionsState,
     mockModelOutputState,
     mockModelRunState,
+    mockReviewInputState,
     mockRootState,
     mockStepperState,
-    mockSurveyAndProgramState,
+    mockSurveyAndProgramState
 } from "../mocks";
 import {RootState} from "../../app/root";
 import {initialMetadataState} from "../../app/store/metadata/metadata";
@@ -46,9 +46,8 @@ describe("Root mutations", () => {
     const populatedState = function () {
         return mockRootState({
             adr: mockADRState({
-                datasets: ["TEST DATASETS"],
+                adrData: mockADRDataState(),
                 schemas: ["TEST SCHEMAS"] as any,
-                fetchingDatasets: true,
                 key: "TEST KEY"
             }),
             reviewInput: mockReviewInputState({
@@ -96,9 +95,8 @@ describe("Root mutations", () => {
 
         //ADR State is always copied
         expect(state.adr).toStrictEqual(mockADRState({
-            datasets: ["TEST DATASETS"],
+            adrData: mockADRDataState(),
             schemas: ["TEST SCHEMAS"] as any,
-            fetchingDatasets: true,
             key: "TEST KEY"
         }));
 


### PR DESCRIPTION
## Description

Sorry fair bit of churn in this one.

We want to add a feature to allow users to load an output zip from the ADR. For some background, when users fit the model they typically import their input data from the [ADR](adr.unaids.org). After the model has fit one of the downloads is an "output zip" and they can choose to download this locally or push it to the ADR. On the projects page we have a "New project" button, under this users can select a local output zip to load the project from. We want to add a new feature to allow users to import this output zip straight from the ADR.

I have already created a PR where we can list ADR datasets which have an output zip in the resources.

We already have an ADR dataset import component. So this PR lays the groundwork to enable us to re-use that component for this new import. There should be no functionality change.

I have:
* Refactored the adr state. We previously had `datasets`, `releases`, `fetchingDatasets` and `adrError`. These are now part of a named object so there can be multiple. Expecting we have `input` which are the current datasets we fetch and `output` for the new type
* Updated actions and mutations to take the `datasetType`
* Split the Modal out of the component into a new one `SelectDatasetModal` which we can re-use. This will be initialised with a prop for the `datasetType` so will manage the switching.
* Split ADR login stuff into a composable `useADR`

## Type of version change

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
