### PR TITLE
[NM-44] Add endpoint for rehydrating from an ADR file

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/RehydrateController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/RehydrateController.kt
@@ -1,7 +1,9 @@
 package org.imperial.mrc.hint.controllers
 
 import org.imperial.mrc.hint.FileManager
+import org.imperial.mrc.hint.FileType
 import org.imperial.mrc.hint.clients.HintrAPIClient
+import org.imperial.mrc.hint.models.AdrResource
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
@@ -15,6 +17,13 @@ class RehydrateController(val apiClient: HintrAPIClient,
     fun submitRehydrate(@RequestParam("file") file: MultipartFile): ResponseEntity<String>
     {
         val outputZip = fileManager.saveOutputZip(file)
+        return apiClient.submitRehydrate(outputZip)
+    }
+
+    @PostMapping("/submit/adr")
+    fun submitAdrRehydrate(@RequestBody data: AdrResource): ResponseEntity<String>
+    {
+        val outputZip = fileManager.saveFile(data, FileType.OutputZip)
         return apiClient.submitRehydrate(outputZip)
     }
 

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/adr/ADRTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/adr/ADRTests.kt
@@ -189,6 +189,16 @@ class ADRTests : SecureIntegrationTests()
     }
 
     @Test
+    fun `can submit rehydrate from ADR output zip`()
+    {
+        val resourceId = extractResourceId(IsAuthorized.TRUE, "inputs-unaids-naomi-output-zip")
+        val file = extractUrl(IsAuthorized.TRUE, "inputs-unaids-naomi-output-zip")
+        val postEntity = getPostEntityWithUrl(AdrResource(file, getDatasetId(IsAuthorized.TRUE), resourceId))
+        val result = testRestTemplate.postForEntity<String>("/rehydrate/submit/adr", postEntity)
+        assertSuccess(result, "ProjectRehydrateSubmitResponse")
+    }
+
+    @Test
     fun `can get ADR schema types`()
     {
         var result = testRestTemplate.getForEntity<String>("/adr/schemas")

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/RehydrateControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/RehydrateControllerTests.kt
@@ -1,16 +1,18 @@
 package org.imperial.mrc.hint.unit.controllers
 
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.*
 import org.assertj.core.api.Assertions.assertThat
 import org.imperial.mrc.hint.FileManager
+import org.imperial.mrc.hint.FileType
 import org.imperial.mrc.hint.clients.HintrAPIClient
+import org.imperial.mrc.hint.controllers.ADRController
 import org.imperial.mrc.hint.controllers.RehydrateController
+import org.imperial.mrc.hint.models.AdrResource
 import org.imperial.mrc.hint.models.VersionFileWithPath
 import org.junit.jupiter.api.Test
 import org.springframework.http.ResponseEntity
 import org.springframework.web.multipart.MultipartFile
+import javax.servlet.http.HttpServletRequest
 
 class RehydrateControllerTests
 {
@@ -31,6 +33,29 @@ class RehydrateControllerTests
 
         val sut = RehydrateController(mockAPIClient, mockFileManager)
         val result = sut.submitRehydrate(multipartFile)
+        verify(mockAPIClient).submitRehydrate(payload)
+        assertThat(result).isSameAs(mockResponse)
+    }
+
+    @Test
+    fun `submit rehydrate from ADR`()
+    {
+        val adrResource = AdrResource("test-url", "123")
+        val payload = VersionFileWithPath("testdata/output.zip", "1", "output", false)
+        val mockResponse = mock<ResponseEntity<String>>()
+
+        val mockFileManager = mock<FileManager> {
+            on {
+                saveFile(any<AdrResource>(), eq(FileType.OutputZip))
+            } doReturn payload
+        }
+        val mockAPIClient = mock<HintrAPIClient> {
+            on { submitRehydrate(payload) } doReturn mockResponse
+        }
+
+        val sut = RehydrateController(mockAPIClient, mockFileManager)
+        val result = sut.submitAdrRehydrate(adrResource)
+        verify(mockFileManager).saveFile(adrResource, FileType.OutputZip)
         verify(mockAPIClient).submitRehydrate(payload)
         assertThat(result).isSameAs(mockResponse)
     }


### PR DESCRIPTION
## Description

I want to add a front end feature to allow users to open a project from an output zip in the ADR. This PR adds a new endpoint to the kotlin backend which will download the file from the ADR resource information and then initiate the rehydrate. See #1011 for some more context
 
## Type of version change

None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
