### PR TITLE
Add duration log for fetching filtered calibrate data

### DIFF
--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/service/CalibrateDataService.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/service/CalibrateDataService.kt
@@ -63,7 +63,11 @@ class CalibrateDataService(
         filterQuery: FilterQuery): List<CalibrateResultRow>
     {
         val path = this.getCalibrateDataPath(id)
-        return calibrateDataRepository.getFilteredCalibrateData(path, filterQuery)
+
+        val data = logDuration({
+            calibrateDataRepository.getFilteredCalibrateData(path, filterQuery)
+        }, logger, "Fetched filtered calibrate data", mutableMapOf<String, String>())
+        return data
     }
 
     private fun getCalibrateDataPath(id: String): Path {


### PR DESCRIPTION
## Description

Adds a log message which returns the duration for fetching filtered calibrate data. Using this to investigate performance on cloud deployment

## Type of version change
_Delete as appropriate_

Major - Minor - Patches - None

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
