### PR TITLE
[NM-67] Fix issue where input comparison data is not refetched when input data is removed or updated

### DIFF
--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.11.0";
+export const currentHintVersion = "3.11.1";

--- a/src/app/static/src/app/store/reviewInput/mutations.ts
+++ b/src/app/static/src/app/store/reviewInput/mutations.ts
@@ -6,6 +6,7 @@ import {Error, InputComparisonResponse, Warning} from "../../generated";
 export enum ReviewInputMutation {
     SetDataset = "SetDataset",
     ClearDataset = "ClearDataset",
+    ClearInputComparison = "ClearInputComparison",
     SetError = "SetError",
     ClearWarnings = "ClearWarnings",
     WarningsFetched = "WarningsFetched",
@@ -26,6 +27,13 @@ export const mutations: MutationTree<ReviewInputState> = {
     },
     [ReviewInputMutation.ClearDataset](state: ReviewInputState, action: PayloadWithType<string>) {
         delete state.datasets[action.payload]
+    },
+    [ReviewInputMutation.ClearInputComparison](state: ReviewInputState) {
+        state.inputComparison = {
+            loading: false,
+            error: null,
+            data: null
+        };
     },
     [ReviewInputMutation.SetError](state: ReviewInputState, action: PayloadWithType<Error | null>) {
         state.error = action.payload;

--- a/src/app/static/src/app/store/surveyAndProgram/actions.ts
+++ b/src/app/static/src/app/store/surveyAndProgram/actions.ts
@@ -39,6 +39,9 @@ const enum DATASET_TYPE {
 
 function commitClearReviewInputDataset(commit: Commit, dataType: string) {
     commit({type: `reviewInput/${ReviewInputMutation.ClearDataset}`, payload: dataType}, {root: true});
+    if (dataType === DATASET_TYPE.ANC || dataType === DATASET_TYPE.ART) {
+        commit({type: `reviewInput/${ReviewInputMutation.ClearInputComparison}`}, {root: true});
+    }
 }
 
 interface UploadImportOptions {

--- a/src/app/static/src/tests/integration/adr-dataset.itest.ts
+++ b/src/app/static/src/tests/integration/adr-dataset.itest.ts
@@ -252,7 +252,10 @@ describe("ADR dataset-related actions", () => {
         expect(dispatch.mock.calls[0][0]).toBe("setProgramResponse");
         expect(dispatch.mock.calls[0][1]["filename"])
             .toBe("programme.csv")
-        expect(commit.mock.calls[3][0]["type"]).toBe(SurveyAndProgramMutation.WarningsFetched);
+        expect(commit.mock.calls[3][0]).toStrictEqual({
+            type: "reviewInput/ClearInputComparison"
+        });
+        expect(commit.mock.calls[4][0]["type"]).toBe(SurveyAndProgramMutation.WarningsFetched);
     }, 10000);
 
     it("can import anc", async () => {
@@ -272,7 +275,10 @@ describe("ADR dataset-related actions", () => {
         expect(dispatch.mock.calls[0][0]).toBe("setAncResponse");
         expect(dispatch.mock.calls[0][1]["filename"])
             .toBe("anc.csv");
-        expect(commit.mock.calls[3][0]["type"]).toBe(SurveyAndProgramMutation.WarningsFetched);
+        expect(commit.mock.calls[3][0]).toStrictEqual({
+            type: "reviewInput/ClearInputComparison"
+        });
+        expect(commit.mock.calls[4][0]["type"]).toBe(SurveyAndProgramMutation.WarningsFetched);
     }, 10000);
 
     it("hits upload files to adr endpoint and gets appropriate error", async () => {

--- a/src/app/static/src/tests/integration/surveyAndProgram.itest.ts
+++ b/src/app/static/src/tests/integration/surveyAndProgram.itest.ts
@@ -49,7 +49,11 @@ describe("Survey and programme actions", () => {
         expect(dispatch.mock.calls[0][0]).toBe("setProgramResponse");
         expect(dispatch.mock.calls[0][1]["filename"]).toBe("programme.csv");
 
-        expect(commit.mock.calls[3][0]["type"]).toBe(SurveyAndProgramMutation.WarningsFetched);
+        expect(commit.mock.calls[3][0]).toStrictEqual({
+            type: "reviewInput/ClearInputComparison"
+        });
+
+        expect(commit.mock.calls[4][0]["type"]).toBe(SurveyAndProgramMutation.WarningsFetched);
     });
 
     it("can upload anc", async () => {
@@ -65,7 +69,11 @@ describe("Survey and programme actions", () => {
         expect(dispatch.mock.calls[0][0]).toBe("setAncResponse");
         expect(dispatch.mock.calls[0][1]["filename"]).toBe("anc.csv");
 
-        expect(commit.mock.calls[3][0]["type"]).toBe(SurveyAndProgramMutation.WarningsFetched);
+        expect(commit.mock.calls[3][0]).toStrictEqual({
+            type: "reviewInput/ClearInputComparison"
+        });
+
+        expect(commit.mock.calls[4][0]["type"]).toBe(SurveyAndProgramMutation.WarningsFetched);
     });
 
     it("can upload VMMC", async () => {

--- a/src/app/static/src/tests/reviewInput/mutations.test.ts
+++ b/src/app/static/src/tests/reviewInput/mutations.test.ts
@@ -1,5 +1,11 @@
 import {mutations} from "../../app/store/reviewInput/mutations";
-import {mockIndicatorMetadata, mockReviewInputState, mockWarning} from "../mocks";
+import {
+    mockIndicatorMetadata,
+    mockInputComparisonData,
+    mockInputComparisonMetadata,
+    mockReviewInputState,
+    mockWarning
+} from "../mocks";
 
 describe("reviewInput mutations", () => {
     it("sets dataset",  () => {
@@ -57,6 +63,26 @@ describe("reviewInput mutations", () => {
             }
         });
     });
+
+    it("can clear input comparison data", () => {
+        const state = mockReviewInputState({
+            inputComparison: {
+                loading: false,
+                data: {
+                    data: mockInputComparisonData(),
+                    metadata: mockInputComparisonMetadata(),
+                    warnings: []
+                },
+                error: null
+            }
+        });
+        mutations.ClearInputComparison(state);
+        expect(state.inputComparison).toEqual({
+            loading: false,
+            data: null,
+            error: null
+        });
+    })
 
     it("sets error", () => {
         const state = mockReviewInputState();

--- a/src/app/static/src/tests/surveyAndProgram/actions.test.ts
+++ b/src/app/static/src/tests/surveyAndProgram/actions.test.ts
@@ -206,7 +206,11 @@ describe("Survey and programme actions", () => {
             payload: "art"
         });
 
-        expect(commit.mock.calls[3][0]).toStrictEqual(
+        expect(commit.mock.calls[3][0]).toStrictEqual({
+            type: "reviewInput/ClearInputComparison"
+        });
+
+        expect(commit.mock.calls[4][0]).toStrictEqual(
             {
                 type: "WarningsFetched",
                 payload: {type: FileType.Programme, warnings: "TEST WARNINGS"}
@@ -239,7 +243,7 @@ describe("Survey and programme actions", () => {
     });
 
     const checkFailedProgramImportUpload = (commit: Mock) => {
-        expect(commit.mock.calls.length).toEqual(5);
+        expect(commit.mock.calls.length).toEqual(6);
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: SurveyAndProgramMutation.ProgramUpdated,
@@ -257,11 +261,15 @@ describe("Survey and programme actions", () => {
         });
 
         expect(commit.mock.calls[3][0]).toStrictEqual({
+            type: "reviewInput/ClearInputComparison"
+        });
+
+        expect(commit.mock.calls[4][0]).toStrictEqual({
             type: SurveyAndProgramMutation.ProgramError,
             payload: mockError("error message")
         });
 
-        expect(commit.mock.calls[4][0]).toStrictEqual({
+        expect(commit.mock.calls[5][0]).toStrictEqual({
             type: SurveyAndProgramMutation.ProgramErroredFile,
             payload: "file.txt"
         });
@@ -310,7 +318,11 @@ describe("Survey and programme actions", () => {
             payload: "anc"
         });
 
-        expect(commit.mock.calls[3][0]).toStrictEqual(
+        expect(commit.mock.calls[3][0]).toStrictEqual({
+            type: "reviewInput/ClearInputComparison"
+        });
+
+        expect(commit.mock.calls[4][0]).toStrictEqual(
             {
                 type: "WarningsFetched",
                 payload: {type: FileType.ANC, warnings: "TEST WARNINGS"}
@@ -343,7 +355,7 @@ describe("Survey and programme actions", () => {
     });
 
     const checkFailedANCImportUpload = (commit: Mock) => {
-        expect(commit.mock.calls.length).toEqual(5);
+        expect(commit.mock.calls.length).toEqual(6);
 
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: SurveyAndProgramMutation.ANCUpdated,
@@ -361,11 +373,15 @@ describe("Survey and programme actions", () => {
         });
 
         expect(commit.mock.calls[3][0]).toStrictEqual({
+            type: "reviewInput/ClearInputComparison"
+        });
+
+        expect(commit.mock.calls[4][0]).toStrictEqual({
             type: SurveyAndProgramMutation.ANCError,
             payload: mockError("error message")
         });
 
-        expect(commit.mock.calls[4][0]).toStrictEqual({
+        expect(commit.mock.calls[5][0]).toStrictEqual({
             type: SurveyAndProgramMutation.ANCErroredFile,
             payload: "file.txt"
         });
@@ -648,13 +664,16 @@ describe("Survey and programme actions", () => {
             rootState,
             state: mockSurveyAndProgramState({survey: mockSurveyResponse()})
         } as any);
-        expect(commit).toBeCalledTimes(3);
+        expect(commit).toBeCalledTimes(4);
         expect(commit.mock.calls[0][0]["type"]).toBe(SurveyAndProgramMutation.ProgramUpdated);
         expect(commit.mock.calls[1][0]).toEqual({
             type: "reviewInput/ClearDataset",
             payload: "art"
         })
-        expect(commit.mock.calls[2][0]).toEqual({
+        expect(commit.mock.calls[2][0]).toStrictEqual({
+            type: "reviewInput/ClearInputComparison"
+        });
+        expect(commit.mock.calls[3][0]).toEqual({
             type: SurveyAndProgramMutation.WarningsFetched,
             payload: {type: FileType.Programme, warnings: []}
         });
@@ -670,13 +689,16 @@ describe("Survey and programme actions", () => {
             rootState,
             state: mockSurveyAndProgramState({program: mockProgramResponse()})
         } as any);
-        expect(commit).toBeCalledTimes(3);
+        expect(commit).toBeCalledTimes(4);
         expect(commit.mock.calls[0][0]["type"]).toBe(SurveyAndProgramMutation.ANCUpdated);
         expect(commit.mock.calls[1][0]).toEqual({
             type: "reviewInput/ClearDataset",
             payload: "anc"
         });
-        expect(commit.mock.calls[2][0]).toEqual({
+        expect(commit.mock.calls[2][0]).toStrictEqual({
+            type: "reviewInput/ClearInputComparison"
+        });
+        expect(commit.mock.calls[3][0]).toEqual({
             type: SurveyAndProgramMutation.WarningsFetched,
             payload: {type: FileType.ANC, warnings: []}
         });
@@ -720,15 +742,17 @@ describe("Survey and programme actions", () => {
         const commit = vi.fn();
         await actions.deleteAll({commit, rootState, state: mockSurveyAndProgramState()} as any);
         expect(mockAxios.history["delete"].length).toBe(4);
-        expect(commit).toBeCalledTimes(11);
+        expect(commit).toBeCalledTimes(13);
         expect(commit.mock.calls.map(c => c[0]["type"])).toEqual([
             SurveyAndProgramMutation.SurveyUpdated,
             SurveyAndProgramMutation.WarningsFetched,
             SurveyAndProgramMutation.ProgramUpdated,
             "reviewInput/ClearDataset",
+            "reviewInput/ClearInputComparison",
             SurveyAndProgramMutation.WarningsFetched,
             SurveyAndProgramMutation.ANCUpdated,
             "reviewInput/ClearDataset",
+            "reviewInput/ClearInputComparison",
             SurveyAndProgramMutation.WarningsFetched,
             SurveyAndProgramMutation.VmmcUpdated,
             "reviewInput/ClearDataset",


### PR DESCRIPTION
## Description
You should be able to check this has worked by
1. Start a new project, upload data and go to one of the input comparison plots. See data is fetched
2. Go to another step and back to input comparison plot, no new data is fetched
3. Go to first step, remove ANC or ART or replace the file
4. Go back to input comparison plot, see data is refetched

Previously it was not being refetched.

## Type of version change

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
