### PR TITLE
Remove transform on table difference icon to display better on most OS/browsers

### DIFF
--- a/src/app/static/src/app/components/plots/table/DifferenceColumnRenderer.vue
+++ b/src/app/static/src/app/components/plots/table/DifferenceColumnRenderer.vue
@@ -1,10 +1,8 @@
 <template>
     <span class="d-inline-flex">
-        <!--Setting a transform to push icon up 1 pixel to align slightly
-        better with the bottom of the text. It is still not perfect.-->
         <span v-if="cellData.icon"
               class="cell-icon mr-1"
-              :style="{ color: cellData.iconColor, transform: 'translateY(-1px)' }">
+              :style="{ color: cellData.iconColor }">
             {{ cellData.icon }}
         </span>
         {{ cellData.cellText }}

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.11.1";
+export const currentHintVersion = "3.11.2";


### PR DESCRIPTION
## Description

Was watching Rachel use this and looks not centre aligned on her browser. I think better not to push this up 1 pixel as that seems to only really improve the look on linux/firefox. Generally looks better without this.

## Type of version change

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
