### PR TITLE
Ensure that download result polling is stopped when outputs are reset

### DIFF
--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.11.2";
+export const currentHintVersion = "3.11.3";

--- a/src/app/static/src/app/store/root/mutations.ts
+++ b/src/app/static/src/app/store/root/mutations.ts
@@ -118,6 +118,10 @@ export const mutations: MutationTree<RootState> = {
     },
 
     [RootMutation.ResetOutputs](state: RootState) {
+        stopPolling(state.downloadResults.spectrum);
+        stopPolling(state.downloadResults.coarseOutput);
+        stopPolling(state.downloadResults.summary);
+        stopPolling(state.downloadResults.comparison);
         stopPolling(state.modelRun);
         stopPolling(state.modelCalibrate);
         Object.assign(state.modelRun, initialModelRunState());


### PR DESCRIPTION
## Description

We can get into a state where the app will poll the download status without an ID repeatedly. To recreate

1. Go to the “Save resutls” stage on a project, wait for status poll to begin
2. Go back to an earlier step and change something which invalidates the later steps e.g. change a model option
3. See that the app will continue to poll `/download/status` without an ID

When the download step is invalidated, we should cancel any polling

## Type of version change

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
