### PR TITLE
[NM-73] fix timing by waiting for baseline data

### DIFF
--- a/src/app/static/src/app/components/Hint.vue
+++ b/src/app/static/src/app/components/Hint.vue
@@ -1,7 +1,11 @@
 <template>
     <user-header :title="title" :user="user"></user-header>
-    <div class="container mb-5">
+    <div class="container mb-5" v-if="baselineReady">
         <router-view></router-view>
+    </div>
+    <div v-else class="text-center">
+        <loading-spinner size="lg"></loading-spinner>
+        <h2 id="loading-message" v-translate="'loadingData'"></h2>
     </div>
     <errors title="title"></errors>
 </template>
@@ -13,6 +17,12 @@ import Errors from "./Errors.vue";
 import {mapActions, mapState} from "vuex";
 import { RootState } from '../root';
 import { Language } from '../store/translations/locales';
+import LoadingSpinner from './LoadingSpinner.vue';
+
+type Computed = {
+    language: (state: RootState) => string,
+    baselineReady: (state: RootState) => boolean
+}
 
     export default defineComponent({
         props: {
@@ -27,10 +37,12 @@ import { Language } from '../store/translations/locales';
         },
         components: {
             UserHeader,
-            Errors
+            Errors,
+            LoadingSpinner
         },
-        computed: mapState<RootState>({
-            language: (state: RootState) => state.language
+        computed: mapState<RootState, Computed>({
+            language: (state: RootState) => state.language,
+            baselineReady: (state: RootState) => state.baseline.ready
         }),
         methods: {
         ...mapActions({loadBaseline: 'baseline/getBaselineData'}),
@@ -42,15 +54,18 @@ import { Language } from '../store/translations/locales';
         },
         beforeMount: function () {
             this.loadBaseline();
-            this.loadSurveyAndProgram();
-            this.loadModelRun();
-            this.loadModelCalibrate();
-            this.getADRSchemas();
-            this.getCurrentProject();
         },
         watch: {
             language(newVal: Language) {
                 document.documentElement.lang = newVal
+            },
+            baselineReady(newVal: boolean) {
+                if (!newVal) return;
+                this.loadSurveyAndProgram();
+                this.loadModelRun();
+                this.loadModelCalibrate();
+                this.getADRSchemas();
+                this.getCurrentProject();
             }
         }
     })

--- a/src/app/static/src/tests/components/app.test.ts
+++ b/src/app/static/src/tests/components/app.test.ts
@@ -85,7 +85,11 @@ describe("App", () => {
             }
         });
         await nextTick();
+
         expect(baselineActions.getBaselineData).toHaveBeenCalled();
+        store.state.baseline.ready = true;
+        await nextTick();
+
         expect(surveyAndProgramActions.getSurveyAndProgramData).toHaveBeenCalled();
         expect(modelRunActions.getResult).toHaveBeenCalled();
         expect(modelCalibrateActions.getResult).toHaveBeenCalled();

--- a/src/app/static/src/tests/router.test.ts
+++ b/src/app/static/src/tests/router.test.ts
@@ -43,6 +43,13 @@ vi.mock("../app/components/Stepper.vue", () => ({
     }
 }))
 
+vi.mock("../app/components/Stepper.vue", () => ({
+    default: {
+        name: "Stepper",
+        template: "<div id='stepper-stub'/>"
+    }
+}))
+
 vi.mock("../app/components/projects/Projects.vue", () => ({
     default: {
         name: "Projects",
@@ -58,7 +65,7 @@ describe("Router", () => {
 
     it("has expected properties", async () => {
         const store = new Vuex.Store({
-            state: mockRootState()
+            state: mockRootState({ baseline: { ready: true } as any })
         })
         const mockTranslate = vi.fn()
         const wrapper = mount(Hint, {


### PR DESCRIPTION
## Description

This was a weird one to find, basically the way loading state works is we save the details of where the files are in local storage and then we just refresh the page, the `Hint.vue` on before mount fetches everything in parallel. This was causing an issue because later parts of our code assume that `state.baseline.shape` exists for example.

I could replicate this pretty easily and consistently if you throttle chrome network speed to "slow 3g" then it happens basically every time with even malawi, it does not occur anymore with this PR

So theres a handy `state.baseline.ready` boolean that i am watching and triggering the rest of the data fetches and that solves it. Theres equivalent "ready"s for `surveryAndProgram`, `modelRun` and `modelCalibrate` states so we can put similar watches in for those if theres some sort of dependency between these, for now just blocking until `baseline` state is fully populated!

PS: other test failures are occuring on main too, see most recent merge to main, i just re ran those, the E2E test failure is correct, seems like the time 1 in "Include ART data" is not yes, the metadata may have changed in a recent naomi/hintr PR and the backend test is just the wrong error message potentially but yh also occuring on main