### PR TITLE
[NM-52] Add base map to bubble plot

### DIFF
--- a/src/app/static/src/app/components/plots/BaseMapCheckbox.vue
+++ b/src/app/static/src/app/components/plots/BaseMapCheckbox.vue
@@ -1,8 +1,8 @@
 <template>
     <l-control position="topleft">
         <div class="checkbox-wrapper">
-            <input type='checkbox' @change="toggleBaseMap" :checked="checked" />
-            <label v-translate="'showBaseMap'"></label>
+            <input id="base-map-checkbox" name="base-map-checkbox" type='checkbox' @change="toggleBaseMap" :checked="checked" />
+            <label for="base-map-checkbox" v-translate="'showBaseMap'"></label>
         </div>
     </l-control>
 </template>

--- a/src/app/static/src/app/components/plots/BaseMapCheckbox.vue
+++ b/src/app/static/src/app/components/plots/BaseMapCheckbox.vue
@@ -1,0 +1,36 @@
+<template>
+    <l-control position="topleft">
+        <div class="checkbox-wrapper">
+            <input type='checkbox' @change="toggleBaseMap" :checked="checked" />
+            <label v-translate="'showBaseMap'"></label>
+        </div>
+    </l-control>
+</template>
+
+<script setup lang="ts">
+import { LControl } from "@vue-leaflet/vue-leaflet";
+
+defineProps({
+    checked: {
+        type: Boolean,
+        required: true
+    },
+})
+
+const emit = defineEmits(['toggle-base-map'])
+
+const toggleBaseMap = () => {
+    emit('toggle-base-map')
+}
+</script>
+
+<style scoped>
+.checkbox-wrapper {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+}
+label {
+    margin-bottom: 0px
+}
+</style>

--- a/src/app/static/src/app/components/plots/bubble/Bubble.vue
+++ b/src/app/static/src/app/components/plots/bubble/Bubble.vue
@@ -7,7 +7,11 @@
                         :geojson="feature"
                         :options-style="() => style">
             </l-geo-json>
-
+            <base-map-checkbox
+                @toggle-base-map="toggleBaseMap"
+                :checked="baseMapVisible"
+            />
+            <l-tile-layer :url="tileLayerUrl" v-if="baseMapVisible"/>
             <map-empty-feature v-if="emptyFeature"></map-empty-feature>
             <template v-else>
                 <reset-map @reset-view="updateBounds"></reset-map>
@@ -30,7 +34,7 @@ import {computed, onMounted, ref, watch} from "vue";
 import {useStore} from "vuex";
 import {RootState} from "../../../root";
 import {PlotData} from "../../../store/plotData/plotData";
-import { LMap, LGeoJson } from "@vue-leaflet/vue-leaflet";
+import { LMap, LGeoJson, LTileLayer } from "@vue-leaflet/vue-leaflet";
 import { Feature } from "geojson";
 import {
     getIndicatorMetadata,
@@ -51,10 +55,13 @@ import SizeLegend from "./SizeLegend.vue";
 import {circleMarker, CircleMarker} from "leaflet";
 import MapEmptyFeature from "../MapEmptyFeature.vue";
 import {getFeatureData, tooltipContent} from "./utils";
+import BaseMapCheckbox from "../BaseMapCheckbox.vue";
 
 const store = useStore<RootState>();
 const plotName = "bubble";
 type OutputData = CalibrateDataResponse["data"]
+
+const tileLayerUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 
 const plotData = computed<PlotData>(() => store.state.plotData[plotName]);
 const getColourIndicator = () => {
@@ -90,6 +97,7 @@ const features = store.state.baseline.shape ?
         store.state.baseline.shape.data.features as Feature[] : [] as Feature[];
 const currentFeatures = ref<Feature[]>([]);
 const featureData = ref<BubbleIndicatorValuesDict>({});
+const baseMapVisible = ref(true);
 
 const map = ref<typeof LMap | null>(null);
 const featureRefs = ref<typeof LGeoJson[]>([]);
@@ -135,6 +143,10 @@ const updateFeatureData = () => {
             10,
             70
     );
+};
+
+const toggleBaseMap = () => {
+    baseMapVisible.value = !baseMapVisible.value
 };
 
 const emptyFeature = computed(() => {

--- a/src/app/static/src/app/components/plots/choropleth/Choropleth.vue
+++ b/src/app/static/src/app/components/plots/choropleth/Choropleth.vue
@@ -8,13 +8,11 @@
                         :options="createTooltips"
                         :options-style="() => getStyle(feature)">
             </l-geo-json>
-            <l-control position="topleft">
-                <div class="checkbox-wrapper">
-                    <input type='checkbox' @change="toggleTileLayer" :checked="tileLayerVisible" />
-                    <label v-translate="'showBaseMap'"></label>
-                </div>
-             </l-control>
-            <l-tile-layer :url="tileLayerUrl" v-if="tileLayerVisible"/>
+            <base-map-checkbox
+                @toggle-base-map="toggleBaseMap"
+                :checked="baseMapVisible"
+            />
+            <l-tile-layer :url="tileLayerUrl" v-if="baseMapVisible"/>
             <map-empty-feature v-if="emptyFeature"></map-empty-feature>
             <template v-else>
                 <reset-map @reset-view="updateBounds"></reset-map>
@@ -32,7 +30,7 @@
 import {PropType, computed, onMounted, ref, toRefs, watch} from "vue";
 import {useStore} from "vuex";
 import {RootState} from "../../../root";
-import { LMap, LGeoJson, LTileLayer, LControl } from "@vue-leaflet/vue-leaflet";
+import { LMap, LGeoJson, LTileLayer } from "@vue-leaflet/vue-leaflet";
 import { Feature } from "geojson";
 import {
     getVisibleFeatures,
@@ -51,6 +49,7 @@ import {useChoroplethTooltips} from "./useChoroplethTooltips";
 import {getFeatureData} from "./utils";
 import MapEmptyFeature from "../MapEmptyFeature.vue";
 import { PlotName } from "../../../store/plotSelections/plotSelections";
+import BaseMapCheckbox from "../BaseMapCheckbox.vue";
 
 const props = defineProps({
     plot: {
@@ -74,7 +73,7 @@ const indicatorMetadata = computed<IndicatorMetadata>(() => {
 const colourRange = ref<NumericRange | null>(null);
 const scaleLevels = ref<ScaleLevels[]>([]);
 const selectedScale = ref<ScaleSettings | null>(null);
-const tileLayerVisible = ref(true);
+const baseMapVisible = ref(true);
 
 const features = store.state.baseline.shape ?
     store.state.baseline.shape.data.features as Feature[] : [] as Feature[];
@@ -113,8 +112,8 @@ const updateFeatures = () => {
     currentFeatures.value = getVisibleFeatures(features, selectedLevel);
 };
 
-const toggleTileLayer = () => {
-    tileLayerVisible.value = !tileLayerVisible.value
+const toggleBaseMap = () => {
+    baseMapVisible.value = !baseMapVisible.value
 }
 
 const selectedAreaIds = computed(() => {
@@ -178,15 +177,3 @@ onMounted(() => {
     updateMapColours();
 });
 </script>
-
-<style scoped>
-.checkbox-wrapper {
-    display: flex;
-    gap: 6px;
-    align-items: center;
-}
-
-label {
-    margin-bottom: 0px
-}
-</style>

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.11.3";
+export const currentHintVersion = "3.11.4";

--- a/src/app/static/src/tests/e2e/outputPlots.spec.ts
+++ b/src/app/static/src/tests/e2e/outputPlots.spec.ts
@@ -95,6 +95,25 @@ test("can view output plots", async ({ projectPage }) => {
     // Then bubble plot is shown
     await expect(page.locator("#review-output")).toHaveScreenshot("bubble-landing.png");
 
+     // Show base map checkbox is shown and checked by default
+     await expect(page.getByRole('checkbox')).toBeVisible()
+     await expect(page.getByRole('checkbox')).toBeChecked()
+     await expect(page.locator(".leaflet-tile-container")).toHaveCount(1);
+ 
+     // When I uncheck show base map checkbox
+     await page.getByRole('checkbox').uncheck();
+ 
+     // Updated map is shown without base map
+     await expect(page.getByRole('checkbox')).not.toBeChecked()
+     await expect(page.locator(".leaflet-tile-container")).toHaveCount(0);
+ 
+     // When I recheck show base map checkbox
+     await page.getByRole('checkbox').check();
+     
+     // Updated map is shown with base map
+     await expect(page.getByRole('checkbox')).toBeChecked()
+     await expect(page.locator(".leaflet-tile-container")).toHaveCount(1);
+
     // When I update the bubble size
     await page.getByRole('link', { name: 'Adjust scale' }).first().click();
     await page.getByText('Custom').click();


### PR DESCRIPTION
## Description

Adds the base map and associated checkbox that are currently in use with choropleth to output bubble plot. Refactored the checkbox into a separate component for consistent use in both maps. Checkbox now uses an emit which is handled in the parent component. Added logic to playwright test for output plots to test functionality similar to choropleth.

## Type of version change

Patch

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
