### PR TITLE
Fix issue with link to privacy and accessibility from login page not working

### DIFF
--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.11.5";
+export const currentHintVersion = "3.11.6";

--- a/src/app/static/src/app/router.ts
+++ b/src/app/static/src/app/router.ts
@@ -1,4 +1,4 @@
-import {createRouter, createWebHashHistory, RouteLocationNormalized} from "vue-router";
+import {createRouter, createWebHistory, RouteLocationNormalized} from "vue-router";
 import Stepper from "./components/Stepper.vue";
 import Accessibility from "./components/Accessibility.vue";
 import Privacy from "./components/Privacy.vue";
@@ -23,6 +23,6 @@ const routes = [
 ];
 
 export const router = createRouter({
-    history: createWebHashHistory(),
+    history: createWebHistory(),
     routes,
 });

--- a/src/app/static/templates/404.ftl
+++ b/src/app/static/templates/404.ftl
@@ -16,15 +16,15 @@
 </div>
 <hr>
 <div class="d-flex justify-content-center">
-    <a href="/"><img src="/public/images/unaids_logo.png" class="large-logo mt-5"/></a>
+    <a href="/" target="_blank"><img src="/public/images/unaids_logo.png" class="large-logo mt-5"/></a>
 </div>
 
 <div id="partner-logos" class="logos d-flex justify-content-center mt-5">
-    <a href="https://www.fjelltopp.org"><img src="/public/images/fjelltopp_logo.png" class="small-logo"></a>
-    <a href="https://www.imperial.ac.uk"><img src="/public/images/imperial_logo.png" class="small-logo"></a>
-    <a href="https://github.com/reside-ic"><img src="/public/images/reside_logo.png" class="small-logo"></a>
-    <a href="https://www.avenirhealth.org"><img src="/public/images/avenir_logo.png" class="small-logo"></a>
-    <a href="https://www.washington.edu"><img src="/public/images/uw_logo.png" class="small-logo"></a>
+    <a href="https://www.fjelltopp.org" target="_blank"><img src="/public/images/fjelltopp_logo.png" class="small-logo"></a>
+    <a href="https://www.imperial.ac.uk" target="_blank"><img src="/public/images/imperial_logo.png" class="small-logo"></a>
+    <a href="https://github.com/reside-ic" target="_blank"><img src="/public/images/reside_logo.png" class="small-logo"></a>
+    <a href="https://www.avenirhealth.org" target="_blank"><img src="/public/images/avenir_logo.png" class="small-logo"></a>
+    <a href="https://www.washington.edu" target="_blank"><img src="/public/images/uw_logo.png" class="small-logo"></a>
 </div>
 </body>
 </html>

--- a/src/app/static/templates/404.ftl
+++ b/src/app/static/templates/404.ftl
@@ -16,15 +16,15 @@
 </div>
 <hr>
 <div class="d-flex justify-content-center">
-    <a href="/"><img src="public/images/unaids_logo.png" class="large-logo mt-5"/></a>
+    <a href="/"><img src="/public/images/unaids_logo.png" class="large-logo mt-5"/></a>
 </div>
 
 <div id="partner-logos" class="logos d-flex justify-content-center mt-5">
-    <a href="https://www.fjelltopp.org"><img src="public/images/fjelltopp_logo.png" class="small-logo"></a>
-    <a href="https://www.imperial.ac.uk"><img src="public/images/imperial_logo.png" class="small-logo"></a>
-    <a href="https://github.com/reside-ic"><img src="public/images/reside_logo.png" class="small-logo"></a>
-    <a href="https://www.avenirhealth.org"><img src="public/images/avenir_logo.png" class="small-logo"></a>
-    <a href="https://www.washington.edu"><img src="public/images/uw_logo.png" class="small-logo"></a>
+    <a href="https://www.fjelltopp.org"><img src="/public/images/fjelltopp_logo.png" class="small-logo"></a>
+    <a href="https://www.imperial.ac.uk"><img src="/public/images/imperial_logo.png" class="small-logo"></a>
+    <a href="https://github.com/reside-ic"><img src="/public/images/reside_logo.png" class="small-logo"></a>
+    <a href="https://www.avenirhealth.org"><img src="/public/images/avenir_logo.png" class="small-logo"></a>
+    <a href="https://www.washington.edu"><img src="/public/images/uw_logo.png" class="small-logo"></a>
 </div>
 </body>
 </html>

--- a/src/app/static/templates/login.ftl
+++ b/src/app/static/templates/login.ftl
@@ -104,7 +104,7 @@
                 </a>
             </div>
         </div>
-        <div id="spacer" class="flex-grow-1"></div>
+        <div id="spacer" class="flex-grow-1 pb-4"></div>
         <div class="links m-auto d-flex flex-row flex-wrap justify-content-between align-items-center">
             <a href="https://reside-ic.github.io/projects/naomi/" target="_blank">About</a>
             <a href="https://naomi.unaids.org/news" target="_blank">News</a>

--- a/src/app/static/templates/login.ftl
+++ b/src/app/static/templates/login.ftl
@@ -30,7 +30,7 @@
 </head>
 <body class="login-page m-0 p-0 h-100">
     <div id="container" class="d-flex flex-column vh-100">
-        <a href="https://www.unaids.org"><img src="public/images/unaids_logo.png" class="large-logo mt-4 mb-4 mx-auto d-flex"/></a>
+        <a href="https://www.unaids.org" target="_blank"><img src="public/images/unaids_logo.png" class="large-logo mt-4 mb-4 mx-auto d-flex"/></a>
         <h1 class="m-0 text-center"><strong>${appTitle}</strong></h1>
         <div id="app" class="card login-form mx-auto mt-3">
             <div class="card-body mx-2">
@@ -79,27 +79,27 @@
         <div id="partners" class="text-center text-muted mt-5">Our partners</div>
         <div class="my-auto mx-5 d-flex flex-row flex-wrap justify-content-center align-items-center">
             <div class="small-logo m-4 d-flex">
-                <a class="d-flex justify-content-center" href="https://www.fjelltopp.org">
+                <a class="d-flex justify-content-center" href="https://www.fjelltopp.org" target="_blank">
                     <img src="public/images/fjelltopp_logo.png" class="mw-100 mh-100">
                 </a>
             </div>
             <div class="small-logo m-4 d-flex">
-                <a class="d-flex justify-content-center" href="https://www.imperial.ac.uk">
+                <a class="d-flex justify-content-center" href="https://www.imperial.ac.uk" target="_blank">
                     <img src="public/images/imperial_logo.png" class="mw-100 mh-100">
                 </a>
             </div>
             <div class="small-logo m-4 d-flex">
-                <a class="d-flex justify-content-center" href="https://github.com/reside-ic">
+                <a class="d-flex justify-content-center" href="https://github.com/reside-ic" target="_blank">
                     <img src="public/images/reside_logo.png" class="mw-100 mh-100">
                 </a>
             </div>
             <div class="small-logo m-4 d-flex">
-                <a class="d-flex justify-content-center" href="https://www.avenirhealth.org">
+                <a class="d-flex justify-content-center" href="https://www.avenirhealth.org" target="_blank">
                     <img src="public/images/avenir_logo.png" class="mw-100 mh-100">
                 </a>
             </div>
             <div class="small-logo m-4 d-flex">
-                <a class="d-flex justify-content-center" href="https://www.washington.edu">
+                <a class="d-flex justify-content-center" href="https://www.washington.edu" target="_blank">
                     <img src="public/images/uw_logo.png" class="mw-100 mh-100">
                 </a>
             </div>


### PR DESCRIPTION
## Description

On the current app if you try to go to privacy or accessibility from the login page you just get redirected back to login page again.

This PR fixes that by switching the history mode, I think this was what was causing the issue. See https://router.vuejs.org/guide/essentials/history-mode.html#HTML5-Mode for details, I think we are safe to switch because of the way we are serving the frontend from freemarker templates. At least comparing this to production, I can't notice any reason not to switch the history mode. Behaviour is the same, and we no longer have the ugly `#` that gets put in the URL.

## Type of version change

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
