### PR TITLE
Calculate the population national proportion up front

### DIFF
--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.13.0";
+export const currentHintVersion = "3.13.1";

--- a/src/app/static/src/app/store/plotSelections/getters.ts
+++ b/src/app/static/src/app/store/plotSelections/getters.ts
@@ -87,7 +87,7 @@ export const getters = {
 
     // Called with already filtered and aggregated PopulationResponseData, this getter transforms the table of
     // data into the format needed for chart js.
-    populationChartData: (state: PlotSelectionsState, getters: any) =>
+    populationChartData: (state: PlotSelectionsState, getters: any, rootState: RootState) =>
         (plotName: PlotName, plotData: PopulationResponseData, ageGroups: FilterOption[]): PopulationChartData => {
 
         const plotType = getters.controlSelectionFromId(plotName, "plot");
@@ -103,7 +103,7 @@ export const getters = {
         // Country data for stepped outline
         let countryData: PopulationChartDataset[] = []
         if (isProportion) {
-            countryData = getSinglePopulationChartDataset({indicators: plotData, ageGroups, isOutline: true, isProportion})
+            countryData = rootState.reviewInput.population.countryLevelData
         }
 
         // Group data by area_id
@@ -126,7 +126,7 @@ export const getters = {
     }
 };
 
-const getSinglePopulationChartDataset = ({
+export const getSinglePopulationChartDataset = ({
                                              indicators,
                                              ageGroups,
                                              isOutline,

--- a/src/app/static/src/app/store/reviewInput/actions.ts
+++ b/src/app/static/src/app/store/reviewInput/actions.ts
@@ -6,6 +6,7 @@ import {ReviewInputDataset} from "../../types";
 import {RootState} from "../../root";
 import {commitPlotDefaultSelections, filtersAfterUseShapeRegions} from "../plotSelections/utils";
 import {InputComparisonResponse, InputPopulationMetadataResponse} from "../../generated";
+import {commitCountryLevelPopulationData} from "./utils";
 
 export interface ReviewInputActions {
     getDataset: (store: ActionContext<ReviewInputState, RootState>, payload: getDatasetPayload) => void
@@ -83,6 +84,7 @@ export const actions: ActionTree<ReviewInputState, RootState> & ReviewInputActio
             .get<InputPopulationMetadataResponse>("/chart-data/input-population")
             .then(async (response) => {
                 if (response) {
+                    await commitCountryLevelPopulationData(commit, rootState, rootGetters);
                     const metadata = response.data;
                     metadata.filterTypes = filtersAfterUseShapeRegions(metadata.filterTypes, rootState);
                     await commitPlotDefaultSelections(metadata, commit, rootState, rootGetters);

--- a/src/app/static/src/app/store/reviewInput/mutations.ts
+++ b/src/app/static/src/app/store/reviewInput/mutations.ts
@@ -1,7 +1,13 @@
 import {MutationTree} from 'vuex';
 import {ReviewInputState} from "./reviewInput";
 import {ReviewInputDataset, PayloadWithType} from "../../types";
-import {Error, InputComparisonResponse, InputPopulationMetadataResponse, Warning} from "../../generated";
+import {
+    Error,
+    InputComparisonResponse,
+    InputPopulationMetadataResponse,
+    Warning
+} from "../../generated";
+import {PopulationChartDataset} from "../plotSelections/plotSelections";
 
 export enum ReviewInputMutation {
     SetDataset = "SetDataset",
@@ -17,6 +23,7 @@ export enum ReviewInputMutation {
     SetPopulationLoading = "SetPopulationLoading",
     SetPopulationError = "SetPopulationError",
     SetPopulationMetadata = "SetPopulationMetadata",
+    SetPopulationCountryLevel = "SetPopulationCountryLevel",
 }
 
 export interface SetDatasetPayload {
@@ -67,5 +74,8 @@ export const mutations: MutationTree<ReviewInputState> = {
     },
     [ReviewInputMutation.SetPopulationMetadata](state: ReviewInputState, action: PayloadWithType<InputPopulationMetadataResponse>) {
         state.population.data = action.payload;
+    },
+    [ReviewInputMutation.SetPopulationCountryLevel](state: ReviewInputState, action: PayloadWithType<PopulationChartDataset[]>) {
+        state.population.countryLevelData = action.payload;
     },
 };

--- a/src/app/static/src/app/store/reviewInput/reviewInput.ts
+++ b/src/app/static/src/app/store/reviewInput/reviewInput.ts
@@ -3,7 +3,13 @@ import {actions} from "./actions";
 import {mutations} from "./mutations";
 import {RootState, WarningsState} from "../../root";
 import {ReviewInputDataset} from "../../types";
-import {Error, FilterOption, InputComparisonResponse, InputPopulationMetadataResponse} from "../../generated";
+import {
+    Error,
+    FilterOption,
+    InputComparisonResponse,
+    InputPopulationMetadataResponse
+} from "../../generated";
+import {PopulationChartDataset} from "../plotSelections/plotSelections";
 
 export interface ReviewInputState extends WarningsState {
     datasets: Record<string, ReviewInputDataset>
@@ -17,7 +23,8 @@ export interface ReviewInputState extends WarningsState {
     population: {
         loading: boolean,
         error: Error | null,
-        data: InputPopulationMetadataResponse | null
+        data: InputPopulationMetadataResponse | null,
+        countryLevelData: PopulationChartDataset[]
     }
 }
 
@@ -35,7 +42,8 @@ export const initialReviewInputState = (): ReviewInputState => {
         population: {
             loading: false,
             error: null,
-            data: null
+            data: null,
+            countryLevelData: [],
         }
     }
 };

--- a/src/app/static/src/app/store/reviewInput/utils.ts
+++ b/src/app/static/src/app/store/reviewInput/utils.ts
@@ -1,0 +1,17 @@
+import {Commit} from "vuex";
+import {RootState} from "../../root";
+import {getSinglePopulationChartDataset} from "../plotSelections/getters";
+import {ReviewInputMutation} from "./mutations";
+
+export const commitCountryLevelPopulationData = async (commit: Commit, rootState: RootState, rootGetters: any) => {
+    const ageGroups = rootGetters["reviewInput/ageGroupOptions"];
+    if (rootState.baseline.population) {
+        const countryData = getSinglePopulationChartDataset({
+            indicators: rootState.baseline.population.data,
+            ageGroups,
+            isOutline: true,
+            isProportion: true
+        });
+        commit({type: ReviewInputMutation.SetPopulationCountryLevel, payload: countryData});
+    }
+}

--- a/src/app/static/src/tests/plotData/filter.test.ts
+++ b/src/app/static/src/tests/plotData/filter.test.ts
@@ -868,7 +868,8 @@ describe("filter tests", () => {
                     population: {
                         data: metadata,
                         error: null,
-                        loading: false
+                        loading: false,
+                        countryLevelData: []
                     }
                 })
             })

--- a/src/app/static/src/tests/plotSelections/getters.test.ts
+++ b/src/app/static/src/tests/plotSelections/getters.test.ts
@@ -9,7 +9,7 @@ import {
     mockRootState,
     mockReviewInputState,
     mockInputComparisonMetadata,
-    mockPopulationDataResponse
+    mockPopulationDataResponse,
 } from "../mocks";
 import {getters, PopulationColors} from "../../app/store/plotSelections/getters";
 import {PlotName} from "../../app/store/plotSelections/plotSelections";
@@ -433,7 +433,9 @@ describe("plotSelections getters", () => {
     ];
 
     it ('population data returns two datasets when population plot type is selected', () => {
-        const getter = getters.populationChartData(mockPlotSelectionsState(), mockGetters);
+        const rootState = mockRootState();
+
+        const getter = getters.populationChartData(mockPlotSelectionsState(), mockGetters, rootState);
 
         const ageGroups = [
             {id:"Y010_014",label:"10-14"},
@@ -470,7 +472,35 @@ describe("plotSelections getters", () => {
             }
         };
 
-        const getter = getters.populationChartData(mockPlotSelectionsState(), mockGetters);
+        const mockCountryLevel = [
+            {
+                label: "Female",
+                data: [0, 3/5, 2/5],
+                backgroundColor: PopulationColors.OUTLINE,
+                isOutline: true,
+                isMale: false
+            },
+            {
+                label: "Male",
+                data: [-0, -5/9, -4/9],
+                backgroundColor: PopulationColors.OUTLINE,
+                isOutline: true,
+                isMale: true
+            }
+        ]
+
+        const rootState = mockRootState({
+            reviewInput: mockReviewInputState({
+                population: {
+                    data: null,
+                    error: null,
+                    loading: false,
+                    countryLevelData: mockCountryLevel
+                }
+            })
+        });
+
+        const getter = getters.populationChartData(mockPlotSelectionsState(), mockGetters, rootState);
 
         const ageGroups = [
             {id:"Y010_014",label:"10-14"},
@@ -498,30 +528,19 @@ describe("plotSelections getters", () => {
             isOutline: false,
             isMale: true
         });
-        expect(datasets[2]).toStrictEqual({
-            label: "Female",
-            data: [0, 3/5, 2/5],
-            backgroundColor: PopulationColors.OUTLINE,
-            isOutline: true,
-            isMale: false
-        });
-        expect(datasets[3]).toStrictEqual({
-            label: "Male",
-            data: [-0, -5/9, -4/9],
-            backgroundColor: PopulationColors.OUTLINE,
-            isOutline: true,
-            isMale: true
-        });
+        expect(datasets[2]).toStrictEqual(mockCountryLevel[0]);
+        expect(datasets[3]).toStrictEqual(mockCountryLevel[1]);
     })
 
     it ('population data returns 0 datasets when plot type not known ', () => {
         const plotData = mockPopulationDataResponse();
+        const rootState = mockRootState();
         const mockGetters = {
             controlSelectionFromId: (plotName: PlotName, controlId: string) => {
                 return null
             }
         };
-        const getter = getters.populationChartData(mockPlotSelectionsState(), mockGetters);
+        const getter = getters.populationChartData(mockPlotSelectionsState(), mockGetters, rootState);
         const ageGroups = [
             {id:"Y010_014",label:"10-14"},
             {id:"Y005_009",label:"5-9"},

--- a/src/app/static/src/tests/reviewInput/actions.test.ts
+++ b/src/app/static/src/tests/reviewInput/actions.test.ts
@@ -2,7 +2,6 @@ import {
     mockAxios,
     mockBaselineState,
     mockFailure,
-    mockInputPopulationMetadataResponse,
     mockPopulationResponse,
     mockRootState,
     mockSuccess
@@ -12,6 +11,8 @@ import {ReviewInputMutation} from "../../app/store/reviewInput/mutations";
 import {freezer} from "../../app/utils";
 import {Mock} from "vitest";
 import * as utils from "../../app/store/plotSelections/utils";
+import * as reviewInputUtils from "../../app/store/reviewInput/utils";
+import {nextTick} from "vue";
 
 describe("reviewInput actions", () => {
     beforeEach(() => {
@@ -110,7 +111,12 @@ describe("reviewInput actions", () => {
         const mockFiltersAfterUseShapeRegions = vi
             .spyOn(utils, "filtersAfterUseShapeRegions")
             .mockImplementation((...args) => []);
+        const mockCommitCountryLevelPopulationData = vi
+            .spyOn(reviewInputUtils, "commitCountryLevelPopulationData")
+            .mockImplementation(async (...args) => {})
         await actions.getPopulationDataset({commit, rootState, rootGetters} as any);
+
+        await nextTick();
 
         expect(commit).toHaveBeenCalledTimes(4);
         expect(commit.mock.calls[0][0]["type"]).toBe(ReviewInputMutation.SetPopulationLoading);
@@ -125,5 +131,6 @@ describe("reviewInput actions", () => {
         expect(mockCommitPlotDefaultSelections).toHaveBeenLastCalledWith({"data": "RESPONSE", filterTypes: []},
             commit, rootState, rootGetters);
         expect(mockFiltersAfterUseShapeRegions).toHaveBeenCalledTimes(1);
+        expect(mockCommitCountryLevelPopulationData).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/app/static/src/tests/reviewInput/mutations.test.ts
+++ b/src/app/static/src/tests/reviewInput/mutations.test.ts
@@ -6,6 +6,7 @@ import {
     mockReviewInputState,
     mockWarning
 } from "../mocks";
+import {PopulationChartDataset} from "../../app/store/plotSelections/plotSelections";
 
 describe("reviewInput mutations", () => {
     it("sets dataset",  () => {
@@ -149,5 +150,20 @@ describe("reviewInput mutations", () => {
         const state = mockReviewInputState();
         mutations.SetPopulationMetadata(state, {payload: inputPopulationMetadataResponse});
         expect(state.population.data).toBe(inputPopulationMetadataResponse);
+    });
+
+    it("sets input population country level data", () => {
+        const inputPopulationCountryData = [
+            {
+                label: "132",
+                data: [1, 2],
+                backgroundColor: "green",
+                isOutline: true,
+                isMale: false
+            }
+        ] as PopulationChartDataset[];
+        const state = mockReviewInputState();
+        mutations.SetPopulationCountryLevel(state, {payload: inputPopulationCountryData});
+        expect(state.population.countryLevelData).toBe(inputPopulationCountryData);
     });
 });

--- a/src/app/static/src/tests/reviewInput/reviewInput.test.ts
+++ b/src/app/static/src/tests/reviewInput/reviewInput.test.ts
@@ -26,7 +26,8 @@ describe("review input getters", () => {
             population: {
                 loading: false,
                 error: null,
-                data: metadata
+                data: metadata,
+                countryLevelData: []
             }
         });
 
@@ -61,7 +62,8 @@ describe("review input getters", () => {
             population: {
                 loading: false,
                 error: null,
-                data: metadata
+                data: metadata,
+                countryLevelData: []
             }
         });
 

--- a/src/app/static/src/tests/reviewInput/utils.test.ts
+++ b/src/app/static/src/tests/reviewInput/utils.test.ts
@@ -1,0 +1,38 @@
+import {commitCountryLevelPopulationData} from "../../app/store/reviewInput/utils";
+import {PopulationResponseData} from "../../app/generated";
+import {mockBaselineState, mockPopulationResponse, mockRootState} from "../mocks";
+
+describe("utils work as expected", () => {
+
+    const mockPopData: PopulationResponseData = [
+        {area_id: "MWI_1_1", area_name: "Northern", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 10},
+        {area_id: "MWI_1_1", area_name: "Northern", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 12},
+        {area_id: "MWI_1_1", area_name: "Northern", calendar_quarter: "CY2018Q1", sex: "female", age_group: "Y000_004", population: 8},
+        {area_id: "MWI_1_1", area_name: "Northern", calendar_quarter: "CY2018Q1", sex: "female", age_group: "Y000_004", population: 5},
+    ];
+
+    const rootState = mockRootState({
+        baseline: mockBaselineState({
+            population: mockPopulationResponse({
+                data: mockPopData
+            })
+        })
+    });
+
+    const rootGetters = {
+        "reviewInput/ageGroupOptions": [
+            {
+                label: "00-04",
+                id: "Y000_004"
+            }
+        ]
+    };
+
+    it("can commit country level population data", () => {
+        const commit = vi.fn();
+        commitCountryLevelPopulationData(commit, rootState, rootGetters);
+
+        expect(commit).toHaveBeenCalledTimes(1);
+        expect(commit.mock.calls[0][0].payload).toHaveLength(2);
+    })
+})

--- a/src/app/static/src/tests/root/actions.test.ts
+++ b/src/app/static/src/tests/root/actions.test.ts
@@ -484,7 +484,8 @@ describe("root actions", () => {
                     population: {
                         loading: false,
                         error: null,
-                        data: {} as any
+                        data: {} as any,
+                        countryLevelData: []
                     }
                 })
             });


### PR DESCRIPTION
## Description

See https://teams.microsoft.com/l/message/19:83f74f91587b4848a35c45bca0c3a2b1@thread.tacv2/1733081977154?tenantId=2b897507-ee8c-4575-830b-4f8267c3d307&groupId=e24ac85e-dd9e-4505-8b9e-047b3a5fa6f0&parentMessageId=1733081977154&teamName=HIV%20Inference%20Group%20-%20WP&channelName=Naomi&createdTime=1733081977154 for some context, the national boundaries are being calculated after filtering. So if they are filtering the area level down to a few districts it won't be the correct boundary.

This fixes that by calculating the national boundaries once up front. I'd like to get this in as a quick fix, but happy to review approach later if we think this isn't quite right.

Ah, actually this won't quite work! Needs to be filtered on the time!

## Type of version change

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
