### PR TITLE
[NM-101] Remove area_name from population data, we can get this from the shape file getters

### DIFF
--- a/src/app/static/src/app/generated.d.ts
+++ b/src/app/static/src/app/generated.d.ts
@@ -2045,7 +2045,6 @@ export interface PlotSettingsControl {
 }
 export interface PopulationDataRow {
   area_id: string;
-  area_name: string;
   calendar_quarter: string;
   sex: string;
   age_group: string;
@@ -2054,7 +2053,6 @@ export interface PopulationDataRow {
 }
 export type PopulationResponseData = {
   area_id: string;
-  area_name: string;
   calendar_quarter: string;
   sex: string;
   age_group: string;
@@ -2635,7 +2633,6 @@ export interface PopulationResponse {
   type: "population";
   data: {
     area_id: string;
-    area_name: string;
     calendar_quarter: string;
     sex: string;
     age_group: string;

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.13.1";
+export const currentHintVersion = "3.13.2";

--- a/src/app/static/src/app/store/plotData/aggregate.ts
+++ b/src/app/static/src/app/store/plotData/aggregate.ts
@@ -15,8 +15,14 @@ export const aggregatePopulation = (data: PopulationResponseData, areaLevel: num
 
     // Population data may be uploaded at multiple area levels. Check to see if there are existing indicators at
     // the selected area level, and if so use them to initialize the aggregation.
-    const existingIndicators = data.filter(ind=>
-        areaIdToPropertiesMap[ind.area_id].area_level === areaLevel)
+    const existingIndicators: PopulationResponseData = data
+        .filter(ind=> areaIdToPropertiesMap[ind.area_id].area_level === areaLevel)
+        .map(ind => {
+                return {
+                    ...ind,
+                    area_name: areaIdToPropertiesMap[ind.area_id].area_name
+                }
+        })
 
     const aggregatePopulationIndicators = () => {
         // Indicators at the most disaggregated area level will be used to create aggregated indicators if they do not already exist.

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -27,7 +27,8 @@ import {
     Warning,
     InputComparisonMetadata,
     InputComparisonData,
-    PopulationResponseData, InputPopulationMetadataResponse
+    PopulationResponseData,
+    InputPopulationMetadataResponse
 } from "../app/generated";
 import {initialModelRunState, ModelRunState} from "../app/store/modelRun/modelRun";
 import {emptyState, RootState} from "../app/root";
@@ -549,7 +550,6 @@ export const mockModelResultResponse = (props: Partial<ModelResultResponse> = {}
 export const mockPopulationDataResponse = (): PopulationResponseData => {
     return [{
         area_id:"MWI_4_10_demo",
-        area_name:"Ntchisi",
         calendar_quarter:"CY2008Q2",
         sex:"female",
         age_group:"Y000_004",

--- a/src/app/static/src/tests/plotData/aggregate.test.ts
+++ b/src/app/static/src/tests/plotData/aggregate.test.ts
@@ -21,18 +21,18 @@ describe("aggregate data", () => {
 
     it("can aggregate population data to different levels", () => {
         const data: PopulationResponseData = [
-            {area_id: "MWI_2_1", area_name: "A", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 10},
-            {area_id: "MWI_2_1", area_name: "A", calendar_quarter: "CY2018Q1", sex: "female", age_group: "Y000_004", population: 12},
-            {area_id: "MWI_2_1", area_name: "A", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y005_009", population: 13},
-            {area_id: "MWI_2_1", area_name: "A", calendar_quarter: "CY2018Q1", sex: "female", age_group: "Y005_009", population: 15},
-            {area_id: "MWI_2_2", area_name: "B", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 9},
-            {area_id: "MWI_2_2", area_name: "B", calendar_quarter: "CY2018Q1", sex: "female", age_group: "Y000_004", population: 8},
-            {area_id: "MWI_2_2", area_name: "B", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y005_009", population: 11},
-            {area_id: "MWI_2_2", area_name: "B", calendar_quarter: "CY2018Q1", sex: "female", age_group: "Y005_009", population: 13},
-            {area_id: "MWI_2_3", area_name: "C", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 23},
-            {area_id: "MWI_2_3", area_name: "C", calendar_quarter: "CY2018Q1", sex: "female", age_group: "Y000_004", population: 22},
-            {area_id: "MWI_2_3", area_name: "C", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y005_009", population: 24},
-            {area_id: "MWI_2_3", area_name: "C", calendar_quarter: "CY2018Q1", sex: "female", age_group: "Y005_009", population: 25}
+            {area_id: "MWI_2_1", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 10},
+            {area_id: "MWI_2_1", calendar_quarter: "CY2018Q1", sex: "female", age_group: "Y000_004", population: 12},
+            {area_id: "MWI_2_1", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y005_009", population: 13},
+            {area_id: "MWI_2_1", calendar_quarter: "CY2018Q1", sex: "female", age_group: "Y005_009", population: 15},
+            {area_id: "MWI_2_2", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 9},
+            {area_id: "MWI_2_2", calendar_quarter: "CY2018Q1", sex: "female", age_group: "Y000_004", population: 8},
+            {area_id: "MWI_2_2", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y005_009", population: 11},
+            {area_id: "MWI_2_2", calendar_quarter: "CY2018Q1", sex: "female", age_group: "Y005_009", population: 13},
+            {area_id: "MWI_2_3", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 23},
+            {area_id: "MWI_2_3", calendar_quarter: "CY2018Q1", sex: "female", age_group: "Y000_004", population: 22},
+            {area_id: "MWI_2_3", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y005_009", population: 24},
+            {area_id: "MWI_2_3", calendar_quarter: "CY2018Q1", sex: "female", age_group: "Y005_009", population: 25}
         ]
 
         const res = aggregatePopulation(data, 1, areaIdToPropertiesMap, areaIdToParentPath)
@@ -60,10 +60,10 @@ describe("aggregate data", () => {
 
     it("groups by calendar quarter when aggregating", () => {
         const data: PopulationResponseData = [
-            {area_id: "MWI_2_1", area_name: "A", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 10},
-            {area_id: "MWI_2_1", area_name: "A", calendar_quarter: "CY2019Q1", sex: "male", age_group: "Y000_004", population: 12},
-            {area_id: "MWI_2_2", area_name: "B", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 9},
-            {area_id: "MWI_2_2", area_name: "B", calendar_quarter: "CY2019Q1", sex: "male", age_group: "Y000_004", population: 8},
+            {area_id: "MWI_2_1", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 10},
+            {area_id: "MWI_2_1", calendar_quarter: "CY2019Q1", sex: "male", age_group: "Y000_004", population: 12},
+            {area_id: "MWI_2_2", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 9},
+            {area_id: "MWI_2_2", calendar_quarter: "CY2019Q1", sex: "male", age_group: "Y000_004", population: 8},
         ];
         const expected: PopulationResponseData = [
             {area_id: "MWI_1_1", area_name: "Northern", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 10 + 9},
@@ -79,11 +79,12 @@ describe("aggregate data", () => {
             {area_id: "MWI_1_1", area_name: "Northern", calendar_quarter: "CY2019Q1", sex: "male", age_group: "Y000_004", population: 400},
         ]
         const data: PopulationResponseData = [
-            ...expected,
-            {area_id: "MWI_2_1", area_name: "A", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 10},
-            {area_id: "MWI_2_1", area_name: "A", calendar_quarter: "CY2019Q1", sex: "male", age_group: "Y000_004", population: 12},
-            {area_id: "MWI_2_2", area_name: "B", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 9},
-            {area_id: "MWI_2_2", area_name: "B", calendar_quarter: "CY2019Q1", sex: "male", age_group: "Y000_004", population: 8},
+            {area_id: "MWI_1_1", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 300},
+            {area_id: "MWI_1_1", calendar_quarter: "CY2019Q1", sex: "male", age_group: "Y000_004", population: 400},
+            {area_id: "MWI_2_1", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 10},
+            {area_id: "MWI_2_1", calendar_quarter: "CY2019Q1", sex: "male", age_group: "Y000_004", population: 12},
+            {area_id: "MWI_2_2", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 9},
+            {area_id: "MWI_2_2", calendar_quarter: "CY2019Q1", sex: "male", age_group: "Y000_004", population: 8},
         ];
         const res = aggregatePopulation(data, 1, areaIdToPropertiesMap, areaIdToParentPath);
         expect(res).toStrictEqual(expected);
@@ -91,8 +92,8 @@ describe("aggregate data", () => {
 
     it("returns empty if asked to aggregate downward", () => {
         const data: PopulationResponseData = [
-            {area_id: "MWI_1_1", area_name: "Northern", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 300},
-            {area_id: "MWI_1_1", area_name: "Northern", calendar_quarter: "CY2019Q1", sex: "male", age_group: "Y000_004", population: 400},
+            {area_id: "MWI_1_1", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 300},
+            {area_id: "MWI_1_1", calendar_quarter: "CY2019Q1", sex: "male", age_group: "Y000_004", population: 400},
         ]
         const res = aggregatePopulation(data, 2, areaIdToPropertiesMap, areaIdToParentPath);
         expect(res).toStrictEqual([]);

--- a/src/app/static/src/tests/plotData/filter.test.ts
+++ b/src/app/static/src/tests/plotData/filter.test.ts
@@ -814,18 +814,18 @@ describe("filter tests", () => {
         } as PlotSelectionUpdate);
 
         const data: PopulationResponseData = [
-            {area_id: "MWI_2_1", area_name: "A", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 10},
-            {area_id: "MWI_2_1", area_name: "A", calendar_quarter: "CY2018Q1", sex: "female", age_group: "Y000_004", population: 12},
-            {area_id: "MWI_2_1", area_name: "A", calendar_quarter: "CY2019Q1", sex: "male", age_group: "Y000_004", population: 13},
-            {area_id: "MWI_2_1", area_name: "A", calendar_quarter: "CY2019Q1", sex: "female", age_group: "Y000_004", population: 15},
-            {area_id: "MWI_2_2", area_name: "B", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 9},
-            {area_id: "MWI_2_2", area_name: "B", calendar_quarter: "CY2018Q1", sex: "female", age_group: "Y000_004", population: 8},
-            {area_id: "MWI_2_2", area_name: "B", calendar_quarter: "CY2019Q1", sex: "male", age_group: "Y000_004", population: 11},
-            {area_id: "MWI_2_2", area_name: "B", calendar_quarter: "CY2019Q1", sex: "female", age_group: "Y000_004", population: 13},
-            {area_id: "MWI_2_3", area_name: "C", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 23},
-            {area_id: "MWI_2_3", area_name: "C", calendar_quarter: "CY2018Q1", sex: "female", age_group: "Y000_004", population: 22},
-            {area_id: "MWI_2_3", area_name: "C", calendar_quarter: "CY2019Q1", sex: "male", age_group: "Y000_004", population: 24},
-            {area_id: "MWI_2_3", area_name: "C", calendar_quarter: "CY2019Q1", sex: "female", age_group: "Y000_004", population: 25}
+            {area_id: "MWI_2_1", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 10},
+            {area_id: "MWI_2_1", calendar_quarter: "CY2018Q1", sex: "female", age_group: "Y000_004", population: 12},
+            {area_id: "MWI_2_1", calendar_quarter: "CY2019Q1", sex: "male", age_group: "Y000_004", population: 13},
+            {area_id: "MWI_2_1", calendar_quarter: "CY2019Q1", sex: "female", age_group: "Y000_004", population: 15},
+            {area_id: "MWI_2_2", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 9},
+            {area_id: "MWI_2_2", calendar_quarter: "CY2018Q1", sex: "female", age_group: "Y000_004", population: 8},
+            {area_id: "MWI_2_2", calendar_quarter: "CY2019Q1", sex: "male", age_group: "Y000_004", population: 11},
+            {area_id: "MWI_2_2", calendar_quarter: "CY2019Q1", sex: "female", age_group: "Y000_004", population: 13},
+            {area_id: "MWI_2_3", calendar_quarter: "CY2018Q1", sex: "male", age_group: "Y000_004", population: 23},
+            {area_id: "MWI_2_3", calendar_quarter: "CY2018Q1", sex: "female", age_group: "Y000_004", population: 22},
+            {area_id: "MWI_2_3", calendar_quarter: "CY2019Q1", sex: "male", age_group: "Y000_004", population: 24},
+            {area_id: "MWI_2_3", calendar_quarter: "CY2019Q1", sex: "female", age_group: "Y000_004", population: 25}
         ]
 
         const metadata = {


### PR DESCRIPTION
## Description

We added this when adding the population plot, but we don't actually need it, and easier to send less data.

## Type of version change

Patches

## Checklist

- [x] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
