### PR TITLE
Fix issue with ART data not refreshing after it has been updated

### DIFF
--- a/src/app/static/src/app/components/common/NumberInput.vue
+++ b/src/app/static/src/app/components/common/NumberInput.vue
@@ -41,7 +41,6 @@ const numberUpdate = (event: any) => {
         val = Math.round(val / step) * step
     }
     if (val > max) {
-        console.log("setting to max ", max)
         val = max
     }
     if (val < min) {

--- a/src/app/static/src/app/components/plots/population/PopulationGrid.vue
+++ b/src/app/static/src/app/components/plots/population/PopulationGrid.vue
@@ -49,7 +49,6 @@ const pageNumber = ref<number>(1);
 watch(
     () => store.state.plotSelections["population"],
     (oldState: PlotSelectionsState["timeSeries"], newState: PlotSelectionsState["timeSeries"]) => {
-        console.log(oldState)
         const oldAreaLevel = oldState.filters.find(f => f.filterId == "area_level")?.selection[0].id;
         const newAreaLevel = newState.filters.find(f => f.filterId == "area_level")?.selection[0].id;
         const oldAreas = oldState.filters.find(f => f.filterId == "area")?.selection;

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.13.4";
+export const currentHintVersion = "3.13.5";

--- a/src/app/static/src/app/store/surveyAndProgram/actions.ts
+++ b/src/app/static/src/app/store/surveyAndProgram/actions.ts
@@ -32,7 +32,7 @@ export interface SurveyAndProgramActions {
 
 const enum DATASET_TYPE {
     ANC = "anc",
-    ART = "art",
+    ART = "programme",
     SURVEY = "survey",
     VMMC = "vmmc"
 }

--- a/src/app/static/src/tests/integration/adr-dataset.itest.ts
+++ b/src/app/static/src/tests/integration/adr-dataset.itest.ts
@@ -247,7 +247,7 @@ describe("ADR dataset-related actions", () => {
 
         expect(commit.mock.calls[2][0]).toStrictEqual({
             type: "reviewInput/ClearDataset",
-            payload: "art"
+            payload: "programme"
         });
         expect(dispatch.mock.calls[0][0]).toBe("setProgramResponse");
         expect(dispatch.mock.calls[0][1]["filename"])

--- a/src/app/static/src/tests/integration/surveyAndProgram.itest.ts
+++ b/src/app/static/src/tests/integration/surveyAndProgram.itest.ts
@@ -44,7 +44,7 @@ describe("Survey and programme actions", () => {
         await actions.uploadProgram({commit, dispatch, rootState} as any, formData);
 
         expect(commit.mock.calls[2][0]["type"]).toBe("reviewInput/ClearDataset");
-        expect(commit.mock.calls[2][0]["payload"]).toBe("art");
+        expect(commit.mock.calls[2][0]["payload"]).toBe("programme");
 
         expect(dispatch.mock.calls[0][0]).toBe("setProgramResponse");
         expect(dispatch.mock.calls[0][1]["filename"]).toBe("programme.csv");

--- a/src/app/static/src/tests/surveyAndProgram/actions.test.ts
+++ b/src/app/static/src/tests/surveyAndProgram/actions.test.ts
@@ -203,7 +203,7 @@ describe("Survey and programme actions", () => {
 
         expect(commit.mock.calls[2][0]).toStrictEqual({
             type: "reviewInput/ClearDataset",
-            payload: "art"
+            payload: "programme"
         });
 
         expect(commit.mock.calls[3][0]).toStrictEqual({
@@ -257,7 +257,7 @@ describe("Survey and programme actions", () => {
 
         expect(commit.mock.calls[2][0]).toStrictEqual({
             type: "reviewInput/ClearDataset",
-            payload: "art"
+            payload: "programme"
         });
 
         expect(commit.mock.calls[3][0]).toStrictEqual({
@@ -668,7 +668,7 @@ describe("Survey and programme actions", () => {
         expect(commit.mock.calls[0][0]["type"]).toBe(SurveyAndProgramMutation.ProgramUpdated);
         expect(commit.mock.calls[1][0]).toEqual({
             type: "reviewInput/ClearDataset",
-            payload: "art"
+            payload: "programme"
         })
         expect(commit.mock.calls[2][0]).toStrictEqual({
             type: "reviewInput/ClearInputComparison"


### PR DESCRIPTION
## Description

If you update the ART data in Naomi, then the input time series was still showing old data. This is because the key we were using to clear it was wrong. It was using "art" when it should have been "programme". This PR fixes that issue, can confirm it by uploading [demo_art_number_modified.csv](https://github.com/user-attachments/files/18111074/demo_art_number_modified.csv) manually or by updating the dataset in the ADR. You should see before this PR the ART data does not update, but after this PR it should do. (Can confirm this by seeing the first point in the first region shown in the time series should change)

## Type of version change

Patches

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
