### PR TITLE
[NM-106] Add tests for page number component

### DIFF
--- a/src/app/static/src/app/components/common/NumberInput.vue
+++ b/src/app/static/src/app/components/common/NumberInput.vue
@@ -46,7 +46,9 @@ const numberUpdate = (event: any) => {
     if (val < min) {
         val = min
     }
-    emit("set-value", val)
+    if (!isNaN(val)) {
+        emit("set-value", val)
+    }
 }
 
 </script>

--- a/src/app/static/src/app/components/common/NumberInput.vue
+++ b/src/app/static/src/app/components/common/NumberInput.vue
@@ -48,6 +48,15 @@ const numberUpdate = (event: any) => {
     }
     if (!isNaN(val)) {
         emit("set-value", val)
+
+        // Explicitly update the input field if the value differs from what's displayed
+        // we do this to prevent the input field being out of sync with the actual value,
+        // this can happen due to 2-way data binding, if e.g. we have max value of 3 but user enters 5
+        // this will update nicely first time, but if the user then enters 5 again, the underlying value
+        // in the parent won't update so the UI doesn't get updated. We need to explicitly update it
+        if (event.target.value !== val.toString()) {
+            event.target.value = val.toString();
+        }
     }
 }
 

--- a/src/app/static/src/app/components/plots/timeSeries/PageControl.vue
+++ b/src/app/static/src/app/components/plots/timeSeries/PageControl.vue
@@ -3,7 +3,7 @@
         <button id="previous-page"
                 class="btn btn-sm mr-2 btn-red"
                 v-translate:aria-label="'previousPage'"
-                :disabled="pageNumber === 1"
+                :disabled="pageNumber == 1"
                 @click="pageUpdate(pageNumber - 1)">
             <vue-feather type="chevron-left" size="20" class="pagination-icon"></vue-feather>
         </button>

--- a/src/app/static/src/app/components/plots/timeSeries/PageControl.vue
+++ b/src/app/static/src/app/components/plots/timeSeries/PageControl.vue
@@ -12,7 +12,6 @@
                       class="mr-1"
                       :value="pageNumber"
                       @set-value="pageUpdate"
-                      type="number"
                       name="page-number-input"
                       :min="1"
                       :max="totalPages"

--- a/src/app/static/src/app/components/plots/timeSeries/PageControl.vue
+++ b/src/app/static/src/app/components/plots/timeSeries/PageControl.vue
@@ -3,7 +3,7 @@
         <button id="previous-page"
                 class="btn btn-sm mr-2 btn-red"
                 v-translate:aria-label="'previousPage'"
-                :disabled="pageNumber == 1"
+                :disabled="pageNumber === 1"
                 @click="pageUpdate(pageNumber - 1)">
             <vue-feather type="chevron-left" size="20" class="pagination-icon"></vue-feather>
         </button>

--- a/src/app/static/src/tests/components/common/numberInput.test.ts
+++ b/src/app/static/src/tests/components/common/numberInput.test.ts
@@ -1,0 +1,56 @@
+import {shallowMount} from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import NumberInput from '../../../app/components/common/NumberInput.vue';
+
+describe('NumberInput.vue', () => {
+    it('emits the adjusted value within min and max bounds', async () => {
+        const wrapper = shallowMount(NumberInput, {
+            props: {
+                min: 10,
+                max: 100,
+                step: 5,
+                value: 25,
+            },
+        });
+
+        const input = wrapper.find('input');
+
+        // Exceeding the max emits max value
+        await input.setValue('105');
+        expect(wrapper.emitted('set-value')).toBeTruthy();
+        expect(wrapper.emitted('set-value')![0]).toEqual([100]);
+
+        // Exceeding the min emits min value
+        await input.setValue('5');
+        expect(wrapper.emitted('set-value')![1]).toEqual([10]);
+
+        // Rounds to the closest step
+        await input.setValue('27');
+        expect(wrapper.emitted('set-value')![2]).toEqual([25]);
+
+        // Converts fractional value
+        await input.setValue('10.7');
+        expect(wrapper.emitted('set-value')).toBeTruthy();
+        expect(wrapper.emitted('set-value')![3]).toEqual([10]);
+
+        // Works if entered value matches constraints
+        await input.setValue('30');
+        expect(wrapper.emitted('set-value')![4]).toEqual([30]);
+    });
+
+    it('does not emit if input is invalid (e.g., non-number)', async () => {
+        const wrapper = shallowMount(NumberInput, {
+            props: {
+                min: 0,
+                max: 10,
+                step: 1,
+                value: 5,
+            },
+        });
+
+        const input = wrapper.find('input');
+
+        await input.setValue('abc');
+        expect(wrapper.emitted('set-value')).toBeFalsy();
+    });
+});

--- a/src/app/static/src/tests/components/plots/timeSeries/pageControl.test.ts
+++ b/src/app/static/src/tests/components/plots/timeSeries/pageControl.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import PageControls from '../../../../app/components/plots/timeSeries/PageControl.vue';
+import NumberInput from '../../../../app/components/common/NumberInput.vue';
+import Vuex from "vuex";
+import {mockRootState} from "../../../mocks";
+import {mount} from "@vue/test-utils";
+
+describe('PageControls.vue', () => {
+
+    const getWrapper = (props: any) => {
+        const store = new Vuex.Store({
+            state: mockRootState(),
+        });
+        return mount(PageControls, {
+            props: props,
+            global: {
+                plugins: [store],
+            }
+        });
+    }
+
+    it('disables the "Previous" button on the first page', () => {
+        const wrapper = getWrapper({
+            pageNumber: 1,
+            totalPages: 10,
+        });
+
+        const prevButton = wrapper.find('#previous-page');
+        expect(prevButton.attributes('disabled')).toBeDefined();
+    });
+
+    it('disables the "Next" button on the last page', () => {
+        const wrapper = getWrapper({
+            pageNumber: 10,
+            totalPages: 10,
+        });
+
+        const nextButton = wrapper.find('#next-page');
+        expect(nextButton.attributes('disabled')).toBeDefined();
+    });
+
+    it('emits "set-page" with the correct value when "Previous" or "Next" is clicked', async () => {
+        const wrapper = getWrapper({
+            pageNumber: 5,
+            totalPages: 10,
+        });
+
+        await wrapper.find('#previous-page').trigger('click');
+        expect(wrapper.emitted('set-page')![0]).toEqual([4]);
+
+        await wrapper.find('#next-page').trigger('click');
+        await expect(wrapper.emitted('set-page')![1]).toEqual([6]);
+    });
+
+    it('emits "set-page" with the correct value when the number input is changed', async () => {
+        const wrapper = getWrapper({
+            pageNumber: 5,
+            totalPages: 10,
+        });
+
+        const numberInput = wrapper.findComponent(NumberInput);
+        numberInput.vm.$emit('set-value', 7);
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.emitted('set-page')![0]).toEqual([7]); // Value from the number input
+    });
+
+    it('renders total pages text correctly', () => {
+        const wrapper = getWrapper({
+            pageNumber: 5,
+            totalPages: 10,
+        });
+
+        const totalPagesText = wrapper.find('#page-number-end');
+        expect(totalPagesText.text()).toBe('of 10');
+    });
+});


### PR DESCRIPTION
## Description

During workshops I added a page number component to allow users to manually enter the page of the plots they wanted to see. I didn't write any automated tests in the hope of getting it in quickly. This PR adds tests for the logic for the paging components.

See #1044 for the original PR.

## Type of version change

None

## Checklist

- [x] I have incremented version number, or version needs no increment
- [x] The build passed successfully, or failed because of ADR tests
