### PR TITLE
Update duckdb to v1.0.0

### DIFF
--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation "org.simplejavamail:simple-java-mail:6.5.0"
     implementation 'jakarta.mail:jakarta.mail-api:1.6.7'
     implementation 'com.sun.activation:jakarta.activation:2.0.1'
-    implementation 'org.duckdb:duckdb_jdbc:0.10.0'
+    implementation 'org.duckdb:duckdb_jdbc:1.0.0'
     implementation 'org.ktorm:ktorm-core:3.6.0'
 
     implementation project(":databaseInterface")

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.14.0";
+export const currentHintVersion = "3.14.1";


### PR DESCRIPTION
## Description

This PR updates the duckdb dependency to v1.0.0

Note we want to do this as R is now on v1.1.3 and it looks like the duckdb version we have here can no longer read files created by that.

I tried updating version here to 1.1.3 too but ran into problems deadlocks see https://github.com/duckdb/duckdb-java/issues/101

We can fix this fairly easily in `getDataFromConnection` by ensuring that the statement are closed before the connection is closed. But not as simple as `getFilteredDataFromConnection` as this is using JOOQ and ktorm to establish the connection, some docs online say that JOOQ is creating a statement under the hood, but I couldn't work out how to fix this from a quick look. I think something I need to look at a bit more closely down the line but not quite got the time right now. 

With version 1.0.0 duckdb can read new results saved by R and also read old output (though we should double check this after deployment)

## Type of version change

Patches

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
