### PR TITLE
Ensure that JSESSIONID cookie has secure flag set

### DIFF
--- a/src/app/src/main/resources/application.properties
+++ b/src/app/src/main/resources/application.properties
@@ -14,5 +14,6 @@ server.compression.mime-types=text/html,text/xml,text/plain,text/css,text/javasc
 # Compress the response only if the response size is at least 1KB
 server.compression.min-response-size=1024
 server.servlet.session.timeout=120m
+server.servlet.session.cookie.secure=true
 logging.config=classpath:logback-spring.xml
 spring.messages.encoding=UTF-8

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.14.5";
+export const currentHintVersion = "3.14.6";


### PR DESCRIPTION
## Description

Feels like a long time since I have written one of these...

We've had a security notice through from UNAIDS IT about JSESSIONID cookie not having 'Secure' attribute. I think not a big deal but something they'd like us to fix.

I've added this secure attribute, and I can see it coming through as such now. The secure attribute prevents the cookie from being sent over HTTP (except on localhost) so can see the "secure" attribute, but we should make sure this works as intended on preview after we deploy it.

## Type of version change

Patches

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
