### PR TITLE
Expose authenticated debug download endpoint for use in cloud deployment

### DIFF
--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -80,6 +80,7 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.4.2"
     testImplementation "org.apache.httpcomponents:httpclient:4.5.12"
+    testImplementation "com.squareup.okhttp3:mockwebserver:4.10.0"
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/AppProperties.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/AppProperties.kt
@@ -50,6 +50,9 @@ interface AppProperties
     val oauth2LoginMethod: Boolean
     val hintrWakeUpInterval: Int?
     val fileTypeMappings: Map<String, String>
+    val githubAuthBaseUrl: String
+    val githubAuthOrg: String
+    val githubAuthTeamSlug: String
 }
 
 //prevent auto-wiring of default Properties
@@ -98,6 +101,9 @@ class ConfiguredAppProperties(
     final override val oauth2ClientScope = propString("oauth2_client_scope")
     final override val oauth2LoginMethod = propString("oauth2_login_method").toBoolean()
     final override val hintrWakeUpInterval = propString("hintr_wake_up_interval_s").toIntOrNull()
+    final override val githubAuthBaseUrl = "https://api.github.com"
+    final override val githubAuthOrg = propString("github_auth_org")
+    final override val githubAuthTeamSlug = propString("github_auth_team_slug")
     final override val fileTypeMappings = mapOf(
             "baseUrl" to adrUrl,
             "anc" to adrANCSchema,

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/AppStart.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/AppStart.kt
@@ -38,6 +38,8 @@ class MvcConfig(val config: Config) : WebMvcConfigurer
         registry.addInterceptor(SecurityInterceptor(config, ""))
                 .addPathPatterns(SecurePaths.ADD.pathList())
                 .excludePathPatterns(SecurePaths.EXCLUDE.pathList())
+        registry.addInterceptor(SecurityInterceptor(config, "githubClient"))
+                .addPathPatterns(SecurePaths.ADD_GITHUB.pathList())
     }
 
     override fun configureAsyncSupport(configurer: AsyncSupportConfigurer)

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/GitHubFuelClient.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/clients/GitHubFuelClient.kt
@@ -1,0 +1,70 @@
+package org.imperial.mrc.hint.clients
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.kittinunf.fuel.core.Headers
+import com.github.kittinunf.fuel.httpGet
+import org.imperial.mrc.hint.AppProperties
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+interface GitHubClient
+{
+    fun getUsername(token: String): String
+    fun isUserInTeam(token: String, username: String): Boolean
+}
+
+@Component
+class GitHubFuelClient(
+    val objectMapper: ObjectMapper,
+    val appProperties: AppProperties
+) : FuelClient(appProperties.githubAuthBaseUrl), GitHubClient
+{
+
+    override fun standardHeaders(): Map<String, Any>
+    {
+        return emptyMap()
+    }
+
+    override fun httpRequestHeaders(): Array<String>
+    {
+        return emptyArray()
+    }
+
+    override fun getUsername(token: String): String {
+        val (_, response, result) = "$baseUrl/user".httpGet()
+            .header(Headers.AUTHORIZATION, "Bearer $token")
+            .addTimeouts()
+            .responseString()
+
+        return result.fold(
+            success = { body ->
+                val json = objectMapper.readTree(body)
+                json["login"]?.asText() ?: throw GitHubApiException("No login field in response")
+            },
+            failure = { error ->
+                throw GitHubApiException("Failed to fetch username: ${response.statusCode} ${error.message}")
+            }
+        )
+    }
+
+    override fun isUserInTeam(token: String, username: String): Boolean
+    {
+        val (_, response, result) = "$baseUrl/orgs/${appProperties.githubAuthOrg}/teams/${appProperties.githubAuthTeamSlug}/memberships/$username".httpGet()
+            .header(Headers.AUTHORIZATION, "Bearer $token")
+            .addTimeouts()
+            .responseString()
+
+        return result.fold(
+            success = { true }, // If we got 200 OK, user is in team
+            failure = { error ->
+                if (response.statusCode == 404) {
+                    false
+                } else {
+                    throw GitHubApiException("Failed to check team membership: ${response.statusCode} ${error.message}")
+                }
+            }
+        )
+    }
+}
+
+class GitHubApiException(message: String) : RuntimeException(message)

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/DebugController.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/controllers/DebugController.kt
@@ -1,0 +1,32 @@
+package org.imperial.mrc.hint.controllers
+
+import org.imperial.mrc.hint.clients.HintrAPIClient
+import org.imperial.mrc.hint.security.Session
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody
+import javax.servlet.http.HttpServletResponse
+
+@RestController
+@RequestMapping("/model")
+class DebugController(
+    val apiClient: HintrAPIClient,
+    private val session: Session
+) {
+
+    private val logger = LoggerFactory.getLogger(DebugController::class.java)
+
+    @GetMapping("/debug/{id}")
+    @ResponseBody
+    fun downloadDebug(@PathVariable("id") id: String, response: HttpServletResponse) {
+        logger.info("in download debug user id is ${session.getUserProfile().id}")
+        if (session.userIsGuest())
+        {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Authentication required")
+        }
+        apiClient.downloadDebug(id, response)
+    }
+
+}

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/HintExceptionHandler.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/exceptions/HintExceptionHandler.kt
@@ -1,6 +1,7 @@
 package org.imperial.mrc.hint.exceptions
 
 import org.imperial.mrc.hint.AppProperties
+import org.imperial.mrc.hint.clients.GitHubApiException
 import org.imperial.mrc.hint.logging.GenericLogger
 import org.imperial.mrc.hint.models.ErrorDetail
 import org.imperial.mrc.hint.models.ErrorDetail.Companion.defaultError
@@ -28,6 +29,7 @@ import java.net.BindException
 import java.text.MessageFormat
 import java.util.*
 import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
 
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @ControllerAdvice
@@ -81,6 +83,15 @@ class HintExceptionHandler(private val errorCodeGenerator: ErrorCodeGenerator,
         logger.error(request, error)
 
         return translatedErrorArgs(error.key, error.args, error.httpStatus, request)
+    }
+
+    @ExceptionHandler(GitHubApiException::class)
+    fun handleGitHubApiException(error: GitHubApiException, request: HttpServletRequest, response: HttpServletResponse): ResponseEntity<Map<String, String>> {
+        logger.error(request, response, error.message)
+
+        return ResponseEntity
+            .status(HttpStatus.BAD_GATEWAY)
+            .body(mapOf("error" to error.message.orEmpty()))
     }
 
     private fun getBundle(request: HttpServletRequest): ResourceBundle

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/security/SecurePaths.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/security/SecurePaths.kt
@@ -2,6 +2,7 @@ package org.imperial.mrc.hint.security
 
 enum class SecurePaths{
 
+    // Secure paths for normal login authenticator
     ADD{
         override fun pathList(): List<String>
         {
@@ -12,6 +13,13 @@ enum class SecurePaths{
         override fun pathList(): List<String>
         {
             return listOf("/adr/schemas", "/adr/schemas/")
+        }
+    },
+    // Secure paths for GitHub authenticator only
+    ADD_GITHUB{
+        override fun pathList(): List<String>
+        {
+            return listOf("/model/debug/**")
         }
     };
 

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/security/SecurityConfig.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/security/SecurityConfig.kt
@@ -2,6 +2,7 @@ package org.imperial.mrc.hint.security
 
 import org.imperial.mrc.hint.db.UserRepository
 import org.imperial.mrc.hint.logic.DbProfileServiceUserLogic.Companion.GUEST_USER
+import org.imperial.mrc.hint.security.github.GitHubAuthenticator
 import org.pac4j.core.config.Config
 import org.pac4j.core.context.WebContext
 import org.pac4j.core.context.session.SessionStore
@@ -31,9 +32,9 @@ class Pac4jConfig
     }
 
     @Bean
-    fun getPac4jConfig(profileService: DbProfileService, userRepository: UserRepository): Config
+    fun getPac4jConfig(profileService: DbProfileService, userRepository: UserRepository, githubAuthenticator: GitHubAuthenticator): Config
     {
-        return HintPac4jConfigService(profileService, userRepository).getConfig()
+        return HintPac4jConfigService(profileService, userRepository, githubAuthenticator).getConfig()
     }
 }
 
@@ -81,7 +82,6 @@ class Session(
     {
         return getUserProfile().id == GUEST_USER
     }
-
 
     fun setRequestedUrl(url: String?)
     {

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/security/github/GitHubAuthService.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/security/github/GitHubAuthService.kt
@@ -1,0 +1,14 @@
+package org.imperial.mrc.hint.security.github
+
+import org.imperial.mrc.hint.clients.GitHubFuelClient
+import org.springframework.stereotype.Service
+
+@Service
+class GitHubAuthService(
+    private val githubFuelClient: GitHubFuelClient,
+) {
+    fun isAuthorized(githubToken: String): Pair<Boolean, String> {
+        val username = githubFuelClient.getUsername(githubToken)
+        return Pair(githubFuelClient.isUserInTeam(githubToken, username), username)
+    }
+}

--- a/src/app/src/main/kotlin/org/imperial/mrc/hint/security/github/GitHubAuthenticator.kt
+++ b/src/app/src/main/kotlin/org/imperial/mrc/hint/security/github/GitHubAuthenticator.kt
@@ -1,0 +1,32 @@
+package org.imperial.mrc.hint.security.github
+
+import org.imperial.mrc.hint.AppProperties
+import org.pac4j.core.context.WebContext
+import org.pac4j.core.context.session.SessionStore
+import org.pac4j.core.credentials.Credentials
+import org.pac4j.core.credentials.TokenCredentials
+import org.pac4j.core.credentials.authenticator.Authenticator
+import org.pac4j.core.exception.CredentialsException
+import org.pac4j.core.profile.CommonProfile
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class GitHubAuthenticator(
+    private val githubAuthService: GitHubAuthService,
+    val appProperties: AppProperties
+) : Authenticator {
+
+    override fun validate(cred: Credentials?, context: WebContext?, sessionStore: SessionStore?) {
+        val credentials = cred as TokenCredentials
+
+        val token = credentials.token
+        val (isAuthorised, username) = githubAuthService.isAuthorized(token)
+
+        when(isAuthorised) {
+            true -> credentials.userProfile = CommonProfile().apply {
+                id = username
+            }
+            false -> throw CredentialsException("Invalid GitHub token or user is not a member of team ${appProperties.githubAuthTeamSlug}")
+        }
+    }
+}

--- a/src/app/src/main/resources/config.properties
+++ b/src/app/src/main/resources/config.properties
@@ -36,3 +36,5 @@ oauth2_client_adr_server_url=http://localhost:5000
 oauth2_login_method=false
 oauth2_client_scope=openid+profile+email+access:adr
 hintr_wake_up_interval_s=120
+github_auth_org=hivtools
+github_auth_team_slug=naomi-debug

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/DebugTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/DebugTests.kt
@@ -1,0 +1,44 @@
+package org.imperial.mrc.hint.integration
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.*
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.slf4j.LoggerFactory
+import org.springframework.boot.test.web.client.getForEntity
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DebugTests: SecureIntegrationTests() {
+    var modelId: String? = null
+    private val logger = LoggerFactory.getLogger(DebugTests::class.java)
+    @BeforeAll
+    fun setupModelId() {
+        authorize()
+        testRestTemplate.getForEntity<String>("/")
+        modelId = waitForModelRunResult()
+        clear()
+    }
+
+    @ParameterizedTest
+    @EnumSource(IsAuthorized::class)
+    fun `can download debug`(isAuthorized: IsAuthorized)
+    {
+        val response = testRestTemplate.getForEntity<ByteArray>("/model/debug/$modelId")
+        assertSecureWithSuccess(isAuthorized, response)
+
+        if (isAuthorized == IsAuthorized.TRUE)
+        {
+            val headers = response.headers
+            Assertions.assertThat(headers["Content-Type"]?.first()).isEqualTo("application/octet-stream")
+
+            val contentLength = headers["Content-Length"]?.first()!!.toInt()
+            Assertions.assertThat(contentLength).isGreaterThan(0)
+            val bodyLength = response.body?.count()
+            Assertions.assertThat(contentLength).isEqualTo(bodyLength)
+        }
+    }
+
+    private fun clear() {
+        testRestTemplate.restTemplate.interceptors.clear()
+    }
+}

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ExceptionHandlerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/integration/ExceptionHandlerTests.kt
@@ -6,6 +6,7 @@ import org.assertj.core.api.Assertions
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.imperial.mrc.hint.AppProperties
 import org.imperial.mrc.hint.ConfiguredAppProperties
+import org.imperial.mrc.hint.clients.GitHubApiException
 import org.imperial.mrc.hint.exceptions.*
 import org.imperial.mrc.hint.helpers.JSONValidator
 import org.imperial.mrc.hint.helpers.Language
@@ -248,6 +249,16 @@ class ExceptionHandlerTests : SecureIntegrationTests()
                 "OTHER_ERROR",
                 "some message")
         assertThat(result.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+    }
+
+    @Test
+    fun `github API exceptions are handled`()
+    {
+        val sut = HintExceptionHandler(mock(), mock(), mock())
+        val exception = GitHubApiException("My github error")
+        val result = sut.handleGitHubApiException(exception, mock(), mock())
+        assertThat(result.statusCode).isEqualTo(HttpStatus.BAD_GATEWAY)
+        assertThat(result.body).isEqualTo(mapOf("error" to "My github error"))
     }
 
     private fun expectTranslatedAdrException(

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/clients/GitHubFuelClientTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/clients/GitHubFuelClientTests.kt
@@ -1,0 +1,132 @@
+package org.imperial.mrc.hint.unit.clients
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.imperial.mrc.hint.AppProperties
+import org.imperial.mrc.hint.clients.GitHubApiException
+import org.imperial.mrc.hint.clients.GitHubFuelClient
+import org.imperial.mrc.hint.helpers.TranslationAssert.Companion.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GitHubFuelClientTest {
+
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var client: GitHubFuelClient
+    private lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
+    fun setup() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+
+        objectMapper = ObjectMapper()
+
+        val mockAppProperties = mock<AppProperties> {
+            on { githubAuthBaseUrl } doReturn mockWebServer.url("/").toString().trimEnd('/')
+            on { githubAuthOrg } doReturn "my-org"
+            on { githubAuthTeamSlug } doReturn "my-team"
+        }
+
+        client = GitHubFuelClient(objectMapper, mockAppProperties)
+    }
+
+    @AfterEach
+    fun teardown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `getUsername returns username on successful response`() {
+        mockWebServer.enqueue(MockResponse()
+            .setResponseCode(200)
+            .setBody("""{"login":"testuser","id":12345}""")
+            .addHeader("Content-Type", "application/json")
+        )
+
+        val result = client.getUsername("valid-token")
+
+        assertThat(result).isEqualTo("testuser")
+
+        val request = mockWebServer.takeRequest()
+        assertThat(request.path).isEqualTo("/user")
+        assertThat(request.getHeader("Authorization")).isEqualTo("Bearer valid-token")
+    }
+
+    @Test
+    fun `getUsername throws GitHubApiException when login field is missing`() {
+        mockWebServer.enqueue(MockResponse()
+            .setResponseCode(200)
+            .setBody("""{"id":12345}""")
+            .addHeader("Content-Type", "application/json")
+        )
+
+        assertThatThrownBy {
+            client.getUsername("valid-token")
+        }
+            .isInstanceOf(GitHubApiException::class.java)
+            .hasMessageContaining("No login field in response")
+    }
+
+    @Test
+    fun `getUsername throws GitHubApiException on HTTP error`() {
+        mockWebServer.enqueue(MockResponse()
+            .setResponseCode(401)
+            .setBody("""{"message":"Bad credentials"}""")
+        )
+
+        assertThatThrownBy {
+            client.getUsername("invalid-token")
+        }
+            .isInstanceOf(GitHubApiException::class.java)
+            .hasMessageContaining("Failed to fetch username: 401")
+    }
+
+    @Test
+    fun `isUserInTeam returns true when user is member`() {
+        mockWebServer.enqueue(MockResponse()
+            .setResponseCode(200)
+            .setBody("""{"state":"active","role":"member"}""")
+            .addHeader("Content-Type", "application/json")
+        )
+
+        val result = client.isUserInTeam("valid-token", "testuser")
+
+        assertThat(result).isTrue()
+
+        val request = mockWebServer.takeRequest()
+        assertThat(request.path).isEqualTo("/orgs/my-org/teams/my-team/memberships/testuser")
+        assertThat(request.getHeader("Authorization")).isEqualTo("Bearer valid-token")
+    }
+
+    @Test
+    fun `isUserInTeam returns false when response is 404`() {
+        mockWebServer.enqueue(MockResponse()
+            .setResponseCode(404)
+            .setBody("""{"message":"Not Found"}""")
+        )
+
+        val result = client.isUserInTeam("valid-token", "testuser")
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `isUserInTeam throws GitHubApiException on other error codes`() {
+        mockWebServer.enqueue(MockResponse()
+            .setResponseCode(500)
+            .setBody("""{"message":"Internal Server Error"}""")
+        )
+
+        assertThatThrownBy {
+            client.isUserInTeam("valid-token", "testuser")
+        }
+            .isInstanceOf(GitHubApiException::class.java)
+            .hasMessageContaining("Failed to check team membership: 500")
+    }
+}

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/DebugControllerTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/controllers/DebugControllerTests.kt
@@ -1,0 +1,29 @@
+package org.imperial.mrc.hint.unit.controllers
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import org.assertj.core.api.Assertions
+import org.imperial.mrc.hint.clients.HintrAPIClient
+import org.imperial.mrc.hint.controllers.DebugController
+import org.imperial.mrc.hint.security.Session
+import org.junit.jupiter.api.Test
+import org.springframework.http.ResponseEntity
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody
+import javax.servlet.http.HttpServletResponse
+
+class DebugControllerTests {
+
+    @Test
+    fun `can get debug download from hintr`()
+    {
+        val mockResponse = mock<HttpServletResponse>()
+        val mockAPIClient = mock<HintrAPIClient>()
+        val mockSession = mock<Session>()
+
+        val sut = DebugController(mockAPIClient, mockSession)
+        sut.downloadDebug("id1", mockResponse)
+        verify(mockAPIClient).downloadDebug("id1", mockResponse)
+    }
+
+}

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/HintPac4jConfigServiceTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/HintPac4jConfigServiceTests.kt
@@ -4,8 +4,11 @@ import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.imperial.mrc.hint.db.UserRepository
 import org.imperial.mrc.hint.security.HintPac4jConfigService
+import org.imperial.mrc.hint.security.github.GitHubAuthenticator
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.pac4j.http.client.direct.DirectBearerAuthClient
 import org.pac4j.http.client.indirect.FormClient
 import org.pac4j.jee.context.session.JEESessionStore
 import org.pac4j.oauth.client.OAuth20Client
@@ -13,30 +16,31 @@ import org.pac4j.sql.profile.service.DbProfileService
 
 class HintPac4jConfigServiceTests
 {
+    companion object {
+        lateinit var configService: HintPac4jConfigService
+        lateinit var mockGitHubAuthenticator: GitHubAuthenticator
+
+        @JvmStatic
+        @BeforeAll
+        fun setUp() {
+            val mockDbProfileService = mock<DbProfileService>()
+            val mockUserRepository = mock<UserRepository>()
+            mockGitHubAuthenticator = mock<GitHubAuthenticator>()
+            configService = HintPac4jConfigService(mockDbProfileService, mockUserRepository, mockGitHubAuthenticator)
+        }
+    }
+
     @Test
     fun `can get config`()
     {
-        val mockDbProfileService = mock<DbProfileService>()
-
-        val mockUserRepository = mock<UserRepository>()
-
-        val sut = HintPac4jConfigService(mockDbProfileService, mockUserRepository)
-
-        assertThat(sut.getConfig().clients.findAllClients().size).isEqualTo(2)
-
-        assertThat(sut.getConfig().clients.callbackUrl).isEqualTo("/callback")
+        assertThat(configService.getConfig().clients.findAllClients().size).isEqualTo(3)
+        assertThat(configService.getConfig().clients.callbackUrl).isEqualTo("/callback")
     }
 
     @Test
     fun `config uses JEESession storage`()
     {
-        val mockDbProfileService = mock<DbProfileService>()
-
-        val mockUserRepository = mock<UserRepository>()
-
-        val sut = HintPac4jConfigService(mockDbProfileService, mockUserRepository)
-
-        val config = sut.getConfig()
+        val config = configService.getConfig()
 
         assertThat(config.sessionStore).isInstanceOf(JEESessionStore::class.java)
     }
@@ -44,13 +48,7 @@ class HintPac4jConfigServiceTests
     @Test
     fun `configures formClient correctly`()
     {
-        val mockDbProfileService = mock<DbProfileService>()
-
-        val mockUserRepository = mock<UserRepository>()
-
-        val sut = HintPac4jConfigService(mockDbProfileService, mockUserRepository)
-
-        val formClient = sut.getConfig().clients.findClient("FormClient").get() as FormClient
+        val formClient = configService.getConfig().clients.findClient("FormClient").get() as FormClient
 
         assertEquals(formClient.loginUrl, "/login")
     }
@@ -58,14 +56,16 @@ class HintPac4jConfigServiceTests
     @Test
     fun `configures oauth2 client correctly`()
     {
-        val mockDbProfileService = mock<DbProfileService>()
-
-        val mockUserRepository = mock<UserRepository>()
-
-        val sut = HintPac4jConfigService(mockDbProfileService, mockUserRepository)
-
-        val oauth2Client = sut.getConfig().clients.findClient("oauth2Client").get() as OAuth20Client
+        val oauth2Client = configService.getConfig().clients.findClient("oauth2Client").get() as OAuth20Client
 
         assertEquals(oauth2Client.callbackUrl, "http://localhost:8080/callback/oauth2Client")
+    }
+
+    @Test
+    fun `configures github client correctly`()
+    {
+        val githubClient = configService.getConfig().clients.findClient("githubClient").get() as DirectBearerAuthClient
+
+        assertEquals(githubClient.authenticator, mockGitHubAuthenticator)
     }
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/Pac4jConfigTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/Pac4jConfigTests.kt
@@ -5,9 +5,11 @@ import org.imperial.mrc.hint.db.UserRepository
 import org.imperial.mrc.hint.security.HintDbProfileService
 import org.imperial.mrc.hint.security.Pac4jConfig
 import org.imperial.mrc.hint.security.SecurePasswordEncoder
+import org.imperial.mrc.hint.security.github.GitHubAuthenticator
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.pac4j.core.client.BaseClient
+import org.pac4j.http.client.direct.DirectBearerAuthClient
 import org.pac4j.http.client.indirect.FormClient
 import org.pac4j.jee.context.session.JEESessionStore
 import org.pac4j.oauth.client.OAuth20Client
@@ -34,14 +36,16 @@ class Pac4jConfigTests
     @Autowired
     private lateinit var userRepository: UserRepository
 
+    @Autowired
+    private lateinit var githubAuthenticator: GitHubAuthenticator
+
     @Test
     fun `can get Pac4j Config for FormLogin`()
     {
-        val config = sut.getPac4jConfig(wiredDbProfileService, userRepository)
+        val config = sut.getPac4jConfig(wiredDbProfileService, userRepository, githubAuthenticator)
 
         assertThat(config.clients.callbackUrl).isEqualTo("/callback")
-
-        assertThat(config.clients.clients.count()).isEqualTo(2)
+        assertThat(config.clients.clients.count()).isEqualTo(3)
 
         val client = config.clients.clients.first()
 
@@ -50,36 +54,38 @@ class Pac4jConfigTests
         val formClient = client as FormClient
 
         assertThat(formClient.loginUrl).isEqualTo("/login")
-
         assertThat(formClient.name).isEqualTo("FormClient")
 
         val field = BaseClient::class.java.getDeclaredField("authenticator")
-
         field.isAccessible = true
 
         assertThat(field.get(client)).isInstanceOf(DbProfileService::class.java)
-
         assertThat(config.sessionStore).isInstanceOf(JEESessionStore::class.java)
     }
 
     @Test
     fun `can get Pac4j Config for OAuth2Login`()
     {
-        val config = sut.getPac4jConfig(wiredDbProfileService, userRepository)
-
-        assertThat(config.clients.callbackUrl).isEqualTo("/callback")
-
-        assertThat(config.clients.clients.count()).isEqualTo(2)
-
-        val client = config.clients.clients.last()
+        val config = sut.getPac4jConfig(wiredDbProfileService, userRepository, githubAuthenticator)
+        val client = config.clients.clients.elementAt(1)
 
         assertThat(client).isInstanceOf(OAuth20Client::class.java)
 
         val oAuth2client = client as OAuth20Client
 
         assertThat(oAuth2client.callbackUrl).isEqualTo("http://localhost:8080/callback/oauth2Client")
-
         assertThat(oAuth2client.name).isEqualTo("oauth2Client")
+        assertThat(config.sessionStore).isInstanceOf(JEESessionStore::class.java)
+    }
+
+    @Test
+    fun `can get Pac4j Config for GitHub login`()
+    {
+        val config = sut.getPac4jConfig(wiredDbProfileService, userRepository, githubAuthenticator)
+        val client = config.clients.clients.last()
+
+        assertThat(client).isInstanceOf(DirectBearerAuthClient::class.java)
+        assertThat(client.name).isEqualTo("githubClient")
 
         assertThat(config.sessionStore).isInstanceOf(JEESessionStore::class.java)
     }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/SecurityConfigTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/SecurityConfigTests.kt
@@ -16,14 +16,16 @@ class SecurityConfigTests
         val sut = MvcConfig(mock())
         val mockInterceptorProject = mock<InterceptorRegistration>() {
             on { addPathPatterns(SecurePaths.ADD.pathList()) } doReturn mock<InterceptorRegistration>()
+            on { addPathPatterns(SecurePaths.ADD_GITHUB.pathList()) } doReturn mock<InterceptorRegistration>()
         }
         val interceptors = mock<InterceptorRegistry>()
         {
             on { addInterceptor(any()) } doReturn mockInterceptorProject
         }
         sut.addInterceptors(interceptors)
-        verify(interceptors, times(1)).addInterceptor(any())
+        verify(interceptors, times(2)).addInterceptor(any())
         verify(mockInterceptorProject, times(1)).addPathPatterns(SecurePaths.ADD.pathList())
+        verify(mockInterceptorProject, times(1)).addPathPatterns(SecurePaths.ADD_GITHUB.pathList())
     }
 
 }

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/github/GitHubAuthServiceTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/github/GitHubAuthServiceTests.kt
@@ -1,0 +1,71 @@
+package org.imperial.mrc.hint.unit.security.github
+
+import com.nhaarman.mockito_kotlin.*
+import org.assertj.core.api.Assertions.assertThat
+import org.imperial.mrc.hint.clients.GitHubApiException
+import org.imperial.mrc.hint.clients.GitHubFuelClient
+import org.imperial.mrc.hint.helpers.TranslationAssert.Companion.assertThatThrownBy
+import org.imperial.mrc.hint.security.github.GitHubAuthService
+import org.junit.jupiter.api.Test
+
+class GitHubAuthServiceTest {
+
+    @Test
+    fun `isAuthorized returns true and username when user is in team`() {
+        val token = "valid-token"
+        val username = "testuser"
+
+        val mockGithubFuelClient = mock<GitHubFuelClient> {
+            on { getUsername(token) } doReturn username
+            on { isUserInTeam(token, username) } doReturn true
+        }
+
+        val service = GitHubAuthService(mockGithubFuelClient)
+        val result = service.isAuthorized(token)
+
+        assertThat(result.first).isTrue()
+        assertThat(result.second).isEqualTo(username)
+        verify(mockGithubFuelClient).getUsername(token)
+        verify(mockGithubFuelClient).isUserInTeam(token, username)
+    }
+
+    @Test
+    fun `isAuthorized returns false and username when user is not in team`() {
+        val token = "valid-token"
+        val username = "testuser"
+
+        val mockGithubFuelClient = mock<GitHubFuelClient> {
+            on { getUsername(token) } doReturn username
+            on { isUserInTeam(token, username) } doReturn false
+        }
+
+        val service = GitHubAuthService(mockGithubFuelClient)
+        val result = service.isAuthorized(token)
+
+        assertThat(result.first).isFalse()
+        assertThat(result.second).isEqualTo(username)
+        verify(mockGithubFuelClient).getUsername(token)
+        verify(mockGithubFuelClient).isUserInTeam(token, username)
+    }
+
+    @Test
+    fun `isAuthorized propagates exception from getUsername`() {
+        val token = "invalid-token"
+        val exception = GitHubApiException("Failed to fetch username")
+
+        val mockGithubFuelClient = mock<GitHubFuelClient> {
+            on { getUsername(token) } doThrow exception
+        }
+
+        val service = GitHubAuthService(mockGithubFuelClient)
+
+        assertThatThrownBy {
+            service.isAuthorized(token)
+        }
+            .isInstanceOf(GitHubApiException::class.java)
+            .hasMessage("Failed to fetch username")
+
+        verify(mockGithubFuelClient).getUsername(token)
+        verify(mockGithubFuelClient, never()).isUserInTeam(any(), any())
+    }
+}

--- a/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/github/GitHubAuthenticatorTests.kt
+++ b/src/app/src/test/kotlin/org/imperial/mrc/hint/unit/security/github/GitHubAuthenticatorTests.kt
@@ -1,0 +1,70 @@
+package org.imperial.mrc.hint.unit.security.github
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.imperial.mrc.hint.AppProperties
+import org.imperial.mrc.hint.security.github.GitHubAuthService
+import org.imperial.mrc.hint.security.github.GitHubAuthenticator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.junit.jupiter.MockitoExtension
+import org.pac4j.core.credentials.TokenCredentials
+import org.pac4j.core.exception.CredentialsException
+import org.pac4j.core.context.WebContext
+import org.pac4j.core.context.session.SessionStore
+
+@ExtendWith(MockitoExtension::class)
+class GitHubAuthenticatorTest {
+
+    @Test
+    fun `validate sets user profile when user is authorized`() {
+        val token = "valid-token"
+        val username = "testuser"
+
+        val mockGithubAuthService = mock<GitHubAuthService> {
+            on { isAuthorized(token) } doReturn Pair(true, username)
+        }
+        val mockAppProperties = mock<AppProperties>()
+        val mockWebContext = mock<WebContext>()
+        val mockSessionStore = mock<SessionStore>()
+
+        val authenticator = GitHubAuthenticator(mockGithubAuthService, mockAppProperties)
+        val credentials = TokenCredentials(token)
+
+        authenticator.validate(credentials, mockWebContext, mockSessionStore)
+
+        assertThat(credentials.userProfile).isNotNull
+        assertThat(credentials.userProfile.id).isEqualTo(username)
+        verify(mockGithubAuthService).isAuthorized(token)
+    }
+
+    @Test
+    fun `validate throws CredentialsException when user is not authorized`() {
+        val token = "invalid-token"
+        val username = "unauthorizeduser"
+        val teamSlug = "my-team"
+
+        val mockGithubAuthService = mock<GitHubAuthService> {
+            on { isAuthorized(token) } doReturn Pair(false, username)
+        }
+        val mockAppProperties = mock<AppProperties> {
+            on { githubAuthTeamSlug } doReturn teamSlug
+        }
+        val mockWebContext = mock<WebContext>()
+        val mockSessionStore = mock<SessionStore>()
+
+        val authenticator = GitHubAuthenticator(mockGithubAuthService, mockAppProperties)
+        val credentials = TokenCredentials(token)
+
+        assertThatThrownBy {
+            authenticator.validate(credentials, mockWebContext, mockSessionStore)
+        }
+            .isInstanceOf(CredentialsException::class.java)
+            .hasMessageContaining("Invalid GitHub token or user is not a member of team $teamSlug")
+
+        verify(mockGithubAuthService).isAuthorized(token)
+    }
+}

--- a/src/app/static/package-lock.json
+++ b/src/app/static/package-lock.json
@@ -6926,7 +6926,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001653",
+      "version": "1.0.30001748",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001748.tgz",
+      "integrity": "sha512-5P5UgAr0+aBmNiplks08JLw+AW/XG/SurlgZLgB1dDLfAw7EfRGxIwzPHxdSCGY/BTKDqIVyJL87cCN6s0ZR0w==",
       "devOptional": true,
       "funding": [
         {
@@ -6941,8 +6943,7 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",

--- a/src/app/static/src/app/hintVersion.ts
+++ b/src/app/static/src/app/hintVersion.ts
@@ -1,1 +1,1 @@
-export const currentHintVersion = "3.14.9";
+export const currentHintVersion = "3.14.10";

--- a/src/docker/config.properties
+++ b/src/docker/config.properties
@@ -20,3 +20,5 @@ oauth2_client_id=${AVENIR_NM_OAUTH2_CLIENT_ID}
 oauth2_client_secret=${AVENIR_NM_OAUTH2_CLIENT_SECRET}
 adr_url=https://adr.unaids.org/
 hintr_wake_up_interval_s=270
+github_auth_org=hivtools
+github_auth_team_slug=naomi-debug


### PR DESCRIPTION
## Description

In the move to the cloud we now don't have an easy secure way to expose the download debug endpoint for Jeff and Rachel. This PR exposes that endpoint via the kotlin API and adds authentication with GitHub to this route. So after this PR users who are a member of the "naomi-debug" team in "hivtools" should be able to call the endpoint. A good test would be to spin this up, give it a go and prove you get an unauthorised error. Then add yourself to the GitHub team and hopefully see it gone.

## Type of version change

Patches

## Checklist

- [ ] I have incremented version number, or version needs no increment
- [ ] The build passed successfully, or failed because of ADR tests
